### PR TITLE
feat: implement delegation system for attestation and management rights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "credence_delegation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["contracts/credence_bond"]
+members = ["contracts/credence_bond", "contracts/credence_delegation"]
 
 [workspace.package]
 version = "0.1.0"

--- a/contracts/credence_delegation/Cargo.toml
+++ b/contracts/credence_delegation/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "credence_delegation"
+version = "0.1.0"
+edition = "2021"
+description = "Credence delegation contract — delegate attestation and management rights"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0", features = ["testutils"] }

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -1,0 +1,138 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum DelegationType {
+    Attestation,
+    Management,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Delegation {
+    pub owner: Address,
+    pub delegate: Address,
+    pub delegation_type: DelegationType,
+    pub expires_at: u64,
+    pub revoked: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Admin,
+    Delegation(Address, Address, DelegationType),
+}
+
+#[contract]
+pub struct CredenceDelegation;
+
+#[contractimpl]
+impl CredenceDelegation {
+    /// Initialize the contract with an admin address.
+    pub fn initialize(e: Env, admin: Address) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        e.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Create a delegation from owner to delegate with a given type and expiry.
+    pub fn delegate(
+        e: Env,
+        owner: Address,
+        delegate: Address,
+        delegation_type: DelegationType,
+        expires_at: u64,
+    ) -> Delegation {
+        owner.require_auth();
+
+        if expires_at <= e.ledger().timestamp() {
+            panic!("expiry must be in the future");
+        }
+
+        let key = DataKey::Delegation(
+            owner.clone(),
+            delegate.clone(),
+            delegation_type.clone(),
+        );
+
+        let d = Delegation {
+            owner: owner.clone(),
+            delegate: delegate.clone(),
+            delegation_type,
+            expires_at,
+            revoked: false,
+        };
+
+        e.storage().instance().set(&key, &d);
+        e.events()
+            .publish((Symbol::new(&e, "delegation_created"),), d.clone());
+
+        d
+    }
+
+    /// Revoke an existing delegation. Only the owner can revoke.
+    pub fn revoke_delegation(
+        e: Env,
+        owner: Address,
+        delegate: Address,
+        delegation_type: DelegationType,
+    ) {
+        owner.require_auth();
+
+        let key = DataKey::Delegation(
+            owner.clone(),
+            delegate.clone(),
+            delegation_type.clone(),
+        );
+
+        let mut d: Delegation = e
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| panic!("delegation not found"));
+
+        if d.revoked {
+            panic!("already revoked");
+        }
+
+        d.revoked = true;
+        e.storage().instance().set(&key, &d);
+        e.events()
+            .publish((Symbol::new(&e, "delegation_revoked"),), d);
+    }
+
+    /// Retrieve a stored delegation.
+    pub fn get_delegation(
+        e: Env,
+        owner: Address,
+        delegate: Address,
+        delegation_type: DelegationType,
+    ) -> Delegation {
+        let key = DataKey::Delegation(owner, delegate, delegation_type);
+        e.storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| panic!("delegation not found"))
+    }
+
+    /// Check whether a delegate is currently valid (not revoked, not expired).
+    pub fn is_valid_delegate(
+        e: Env,
+        owner: Address,
+        delegate: Address,
+        delegation_type: DelegationType,
+    ) -> bool {
+        let key = DataKey::Delegation(owner, delegate, delegation_type);
+        match e.storage().instance().get::<_, Delegation>(&key) {
+            Some(d) => !d.revoked && d.expires_at > e.ledger().timestamp(),
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/credence_delegation/src/test.rs
+++ b/contracts/credence_delegation/src/test.rs
@@ -1,0 +1,249 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::Env;
+
+#[test]
+fn test_delegate_attestation() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    let d = client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+
+    assert_eq!(d.owner, owner);
+    assert_eq!(d.delegate, delegate);
+    assert_eq!(d.expires_at, 86400);
+    assert!(!d.revoked);
+    assert!(matches!(d.delegation_type, DelegationType::Attestation));
+}
+
+#[test]
+fn test_delegate_management() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    let d = client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
+
+    assert_eq!(d.owner, owner);
+    assert_eq!(d.delegate, delegate);
+    assert!(matches!(d.delegation_type, DelegationType::Management));
+}
+
+#[test]
+fn test_get_delegation() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+
+    let d = client.get_delegation(&owner, &delegate, &DelegationType::Attestation);
+    assert_eq!(d.owner, owner);
+    assert_eq!(d.delegate, delegate);
+    assert_eq!(d.expires_at, 86400);
+}
+
+#[test]
+fn test_revoke_delegation() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+
+    let d = client.get_delegation(&owner, &delegate, &DelegationType::Attestation);
+    assert!(d.revoked);
+}
+
+#[test]
+fn test_is_valid_delegate() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+
+    assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
+}
+
+#[test]
+fn test_is_valid_delegate_not_found() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
+}
+
+#[test]
+fn test_is_valid_delegate_after_revoke() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Management);
+
+    assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
+}
+
+#[test]
+fn test_is_valid_delegate_after_expiry() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &100_u64);
+
+    assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
+
+    // Advance ledger past expiry
+    e.ledger().with_mut(|li| {
+        li.timestamp = 200;
+    });
+
+    assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
+}
+
+#[test]
+fn test_independent_delegation_types() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
+
+    // Revoke only attestation
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+
+    assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
+    assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_double_initialize() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let admin2 = Address::generate(&e);
+    client.initialize(&admin2);
+}
+
+#[test]
+#[should_panic(expected = "expiry must be in the future")]
+fn test_delegate_with_past_expiry() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &500_u64);
+}
+
+#[test]
+#[should_panic(expected = "delegation not found")]
+fn test_get_nonexistent_delegation() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.get_delegation(&owner, &delegate, &DelegationType::Attestation);
+}
+
+#[test]
+#[should_panic(expected = "already revoked")]
+fn test_double_revoke() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+}

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -1,0 +1,73 @@
+# Delegation System
+
+Soroban contract enabling bond owners to delegate attestation and management rights to other addresses.
+
+## Overview
+
+The `CredenceDelegation` contract stores delegations keyed by `(owner, delegate, DelegationType)`. Each delegation carries an expiry timestamp and can be revoked by the owner at any time.
+
+## Types
+
+### DelegationType
+
+| Variant       | Description                              |
+|---------------|------------------------------------------|
+| Attestation   | Delegate can attest on behalf of owner   |
+| Management    | Delegate can manage bonds on behalf of owner |
+
+### Delegation
+
+| Field            | Type            | Description                      |
+|------------------|-----------------|----------------------------------|
+| owner            | Address         | Bond owner granting delegation   |
+| delegate         | Address         | Address receiving delegated rights |
+| delegation_type  | DelegationType  | Kind of delegation               |
+| expires_at       | u64             | Ledger timestamp when delegation expires |
+| revoked          | bool            | Whether the delegation was revoked |
+
+## Contract Functions
+
+### `initialize(admin: Address)`
+
+Set the contract admin. Can only be called once.
+
+### `delegate(owner, delegate, delegation_type, expires_at) -> Delegation`
+
+Create a delegation. Requires owner authorization. `expires_at` must be a future timestamp. Emits a `delegation_created` event.
+
+### `revoke_delegation(owner, delegate, delegation_type)`
+
+Revoke an active delegation. Requires owner authorization. Panics if the delegation does not exist or is already revoked. Emits a `delegation_revoked` event.
+
+### `get_delegation(owner, delegate, delegation_type) -> Delegation`
+
+Retrieve a stored delegation. Panics if not found.
+
+### `is_valid_delegate(owner, delegate, delegation_type) -> bool`
+
+Returns `true` if the delegation exists, is not revoked, and has not expired. Returns `false` otherwise (including when no delegation exists).
+
+## Events
+
+| Event                | Data        | Emitted when              |
+|----------------------|-------------|---------------------------|
+| delegation_created   | Delegation  | A new delegation is stored |
+| delegation_revoked   | Delegation  | A delegation is revoked    |
+
+## Security
+
+- Only the owner can create or revoke their delegations (`require_auth`).
+- Delegations are time-bound; expired delegations are treated as invalid.
+- Double initialization is rejected.
+- Double revocation is rejected.
+- Each `(owner, delegate, type)` tuple maps to exactly one delegation record.
+
+## Usage
+
+```bash
+# Build
+cargo build -p credence_delegation
+
+# Test
+cargo test -p credence_delegation
+```


### PR DESCRIPTION
Closes #56
## Summary

Implements the delegation system described in #56, allowing bond owners
to delegate attestation and management rights to other addresses.

## Changes

- New contract crate `contracts/credence_delegation/` with:
  - `DelegationType` enum (Attestation, Management)
  - `Delegation` struct with owner, delegate, type, expiry, revoked fields
  - `initialize()` — single-use admin setup
  - `delegate()` — create time-bound delegation (requires owner auth)
  - `revoke_delegation()` — revoke active delegation (requires owner auth)
  - `get_delegation()` — query stored delegation
  - `is_valid_delegate()` — check delegation is active and not expired
- Events emitted on creation (`delegation_created`) and revocation (`delegation_revoked`)
- 13 unit tests covering all functions, error paths, expiry, and type independence
- Documentation at `docs/delegation.md`
- Workspace Cargo.toml updated to include the new crate

- Add credence_delegation contract with delegate, revoke, query, and validation
- Support attestation and management delegation types
- Track delegation expiry and revocation state
- Emit delegation_created and delegation_revoked events
- Add 13 tests covering all functions and error paths
- Add docs/delegation.md

## Testing

- `cargo test -p credence_delegation` — 13 passed, 0 failed
- `cargo test -p credence_bond` — 1 passed (existing test unaffected)
