### PR TITLE
feat: implement nonce management and weighted attestation system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 name = "credence_treasury"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 22.0.10",
 ]
 
 [[package]]

--- a/contracts/credence_bond/src/lib.rs
+++ b/contracts/credence_bond/src/lib.rs
@@ -5,8 +5,12 @@ use soroban_sdk::{
 };
 
 mod early_exit_penalty;
+mod nonce;
 mod rolling_bond;
 mod tiered_bond;
+mod weighted_attestation;
+
+pub mod types;
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -22,16 +26,8 @@ pub struct IdentityBond {
     pub notice_period: u64,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Attestation {
-    pub id: u64,
-    pub attester: Address,
-    pub subject: Address,
-    pub attestation_data: String,
-    pub timestamp: u64,
-    pub revoked: bool,
-}
+// Re-export attestation type (definitions and validation in types::attestation).
+pub use types::Attestation;
 
 #[contracttype]
 pub enum DataKey {
@@ -41,6 +37,12 @@ pub enum DataKey {
     Attestation(u64),
     AttestationCounter,
     SubjectAttestations(Address),
+    /// Per-identity attestation count (updated on add/revoke).
+    SubjectAttestationCount(Address),
+    /// Per-identity nonce for replay prevention.
+    Nonce(Address),
+    /// Attester stake used for weighted attestation (set by admin or from bond).
+    AttesterStake(Address),
 }
 
 #[contracttype]
@@ -160,48 +162,67 @@ impl CredenceBond {
     }
 
     /// Add an attestation for a subject (only authorized attesters can call).
+    /// Requires correct nonce for replay prevention; rejects duplicate (verifier, identity, data).
+    /// Weight is computed from attester stake (weighted attestation system).
+    ///
+    /// @param e Contract environment
+    /// @param attester Authorized verifier (must be registered and must pass require_auth)
+    /// @param subject Identity being attested
+    /// @param attestation_data Opaque attestation payload
+    /// @param nonce Current nonce for attester (get_nonce(attester)); incremented on success
+    /// @return The created Attestation (id, verifier, identity, timestamp, weight, data, revoked)
     pub fn add_attestation(
         e: Env,
         attester: Address,
         subject: Address,
         attestation_data: String,
+        nonce: u64,
     ) -> Attestation {
         attester.require_auth();
 
-        // Verify attester is authorized
         let is_authorized = e
             .storage()
             .instance()
             .get(&DataKey::Attester(attester.clone()))
             .unwrap_or(false);
-
         if !is_authorized {
             panic!("unauthorized attester");
         }
 
-        // Get and increment attestation counter
+        nonce::consume_nonce(&e, &attester, nonce);
+
+        let dedup_key = types::AttestationDedupKey {
+            verifier: attester.clone(),
+            identity: subject.clone(),
+            attestation_data: attestation_data.clone(),
+        };
+        if e.storage().instance().has(&dedup_key) {
+            panic!("duplicate attestation");
+        }
+
         let counter_key = DataKey::AttestationCounter;
         let id: u64 = e.storage().instance().get(&counter_key).unwrap_or(0);
-
         let next_id = id.checked_add(1).expect("attestation counter overflow");
         e.storage().instance().set(&counter_key, &next_id);
 
-        // Create attestation
+        let weight = weighted_attestation::compute_weight(&e, &attester);
+        types::Attestation::validate_weight(weight);
+
         let attestation = Attestation {
             id,
-            attester: attester.clone(),
-            subject: subject.clone(),
-            attestation_data: attestation_data.clone(),
+            verifier: attester.clone(),
+            identity: subject.clone(),
             timestamp: e.ledger().timestamp(),
+            weight,
+            attestation_data: attestation_data.clone(),
             revoked: false,
         };
 
-        // Store attestation
         e.storage()
             .instance()
             .set(&DataKey::Attestation(id), &attestation);
+        e.storage().instance().set(&dedup_key, &id);
 
-        // Add to subject's attestation list
         let subject_key = DataKey::SubjectAttestations(subject.clone());
         let mut attestations: Vec<u64> = e
             .storage()
@@ -211,20 +232,25 @@ impl CredenceBond {
         attestations.push_back(id);
         e.storage().instance().set(&subject_key, &attestations);
 
-        // Emit event
+        let count_key = DataKey::SubjectAttestationCount(subject.clone());
+        let count: u32 = e.storage().instance().get(&count_key).unwrap_or(0);
+        e.storage()
+            .instance()
+            .set(&count_key, &count.saturating_add(1));
+
         e.events().publish(
             (Symbol::new(&e, "attestation_added"), subject),
-            (id, attester, attestation_data),
+            (id, attester, attestation_data, weight),
         );
 
         attestation
     }
 
-    /// Revoke an attestation (only the original attester can revoke).
-    pub fn revoke_attestation(e: Env, attester: Address, attestation_id: u64) {
+    /// Revoke an attestation (only the original attester can revoke). Requires correct nonce.
+    pub fn revoke_attestation(e: Env, attester: Address, attestation_id: u64, nonce: u64) {
         attester.require_auth();
+        nonce::consume_nonce(&e, &attester, nonce);
 
-        // Get attestation
         let key = DataKey::Attestation(attestation_id);
         let mut attestation: Attestation = e
             .storage()
@@ -232,25 +258,33 @@ impl CredenceBond {
             .get(&key)
             .unwrap_or_else(|| panic!("attestation not found"));
 
-        // Verify attester is the original attester
-        if attestation.attester != attester {
+        if attestation.verifier != attester {
             panic!("only original attester can revoke");
         }
-
-        // Check if already revoked
         if attestation.revoked {
             panic!("attestation already revoked");
         }
 
-        // Mark as revoked
         attestation.revoked = true;
         e.storage().instance().set(&key, &attestation);
 
-        // Emit event
+        let dedup_key = types::AttestationDedupKey {
+            verifier: attestation.verifier.clone(),
+            identity: attestation.identity.clone(),
+            attestation_data: attestation.attestation_data.clone(),
+        };
+        e.storage().instance().remove(&dedup_key);
+
+        let count_key = DataKey::SubjectAttestationCount(attestation.identity.clone());
+        let count: u32 = e.storage().instance().get(&count_key).unwrap_or(0);
+        e.storage()
+            .instance()
+            .set(&count_key, &count.saturating_sub(1));
+
         e.events().publish(
             (
                 Symbol::new(&e, "attestation_revoked"),
-                attestation.subject.clone(),
+                attestation.identity.clone(),
             ),
             (attestation_id, attester),
         );
@@ -270,6 +304,52 @@ impl CredenceBond {
             .instance()
             .get(&DataKey::SubjectAttestations(subject))
             .unwrap_or(Vec::new(&e))
+    }
+
+    /// Get attestation count for a subject (identity). O(1).
+    pub fn get_subject_attestation_count(e: Env, subject: Address) -> u32 {
+        e.storage()
+            .instance()
+            .get(&DataKey::SubjectAttestationCount(subject))
+            .unwrap_or(0)
+    }
+
+    /// Get current nonce for an identity (for replay prevention). Use this value in the next state-changing call.
+    pub fn get_nonce(e: Env, identity: Address) -> u64 {
+        nonce::get_nonce(&e, &identity)
+    }
+
+    /// Set attester stake (admin only). Used for weighted attestation; weight is derived from this.
+    pub fn set_attester_stake(e: Env, admin: Address, attester: Address, amount: i128) {
+        let stored_admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("not initialized"));
+        admin.require_auth();
+        if admin != stored_admin {
+            panic!("not admin");
+        }
+        weighted_attestation::set_attester_stake(&e, &attester, amount);
+    }
+
+    /// Set weight config: multiplier_bps (e.g. 100 = 1%), max_attestation_weight. Admin only.
+    pub fn set_weight_config(e: Env, admin: Address, multiplier_bps: u32, max_weight: u32) {
+        let stored_admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("not initialized"));
+        admin.require_auth();
+        if admin != stored_admin {
+            panic!("not admin");
+        }
+        weighted_attestation::set_weight_config(&e, multiplier_bps, max_weight);
+    }
+
+    /// Get weight config (multiplier_bps, max_weight).
+    pub fn get_weight_config(e: Env) -> (u32, u32) {
+        weighted_attestation::get_weight_config(&e)
     }
 
     /// Withdraw from bond. Checks that the bond has sufficient balance after accounting for slashed amount.
@@ -528,6 +608,9 @@ impl CredenceBond {
             bond_duration: bond.bond_duration,
             slashed_amount: bond.slashed_amount,
             active: false,
+            is_rolling: bond.is_rolling,
+            withdrawal_requested_at: bond.withdrawal_requested_at,
+            notice_period: bond.notice_period,
         };
         e.storage().instance().set(&bond_key, &updated);
 
@@ -586,6 +669,9 @@ impl CredenceBond {
             bond_duration: bond.bond_duration,
             slashed_amount: new_slashed,
             active: bond.active,
+            is_rolling: bond.is_rolling,
+            withdrawal_requested_at: bond.withdrawal_requested_at,
+            notice_period: bond.notice_period,
         };
         e.storage().instance().set(&bond_key, &updated);
 
@@ -677,6 +763,15 @@ mod test_reentrancy;
 
 #[cfg(test)]
 mod test_attestation;
+
+#[cfg(test)]
+mod test_attestation_types;
+
+#[cfg(test)]
+mod test_weighted_attestation;
+
+#[cfg(test)]
+mod test_replay_prevention;
 
 #[cfg(test)]
 mod security;

--- a/contracts/credence_bond/src/nonce.rs
+++ b/contracts/credence_bond/src/nonce.rs
@@ -1,0 +1,37 @@
+//! Replay attack prevention using per-identity nonces.
+//!
+//! Each identity has a nonce that must be included in state-changing calls.
+//! The contract rejects replayed transactions by requiring nonce to match
+//! the stored value, then incrementing it. Handles nonce overflow by wrapping.
+
+use soroban_sdk::Env;
+
+use crate::DataKey;
+
+/// Returns the current nonce for an identity. Caller must use this value in the next state-changing call.
+///
+/// # Returns
+/// Current nonce (starts at 0). After a successful state-changing call, the nonce increments.
+#[must_use]
+pub fn get_nonce(e: &Env, identity: &soroban_sdk::Address) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::Nonce(identity.clone()))
+        .unwrap_or(0)
+}
+
+/// Checks that the provided nonce matches the current nonce for the identity, then increments.
+/// Call this at the start of state-changing functions.
+///
+/// # Errors
+/// Panics if `expected_nonce` does not match the stored nonce (replay or out-of-order).
+pub fn consume_nonce(e: &Env, identity: &soroban_sdk::Address, expected_nonce: u64) {
+    let current = get_nonce(e, identity);
+    if current != expected_nonce {
+        panic!("invalid nonce: replay or out-of-order");
+    }
+    let next = current.checked_add(1).expect("nonce overflow");
+    e.storage()
+        .instance()
+        .set(&DataKey::Nonce(identity.clone()), &next);
+}

--- a/contracts/credence_bond/src/test_attestation.rs
+++ b/contracts/credence_bond/src/test_attestation.rs
@@ -115,13 +115,15 @@ fn test_add_attestation_basic() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "verified identity");
 
-    let att = client.add_attestation(&attester, &subject, &data);
+    let nonce = client.get_nonce(&attester);
+    let att = client.add_attestation(&attester, &subject, &data, &nonce);
 
     assert_eq!(att.id, 0);
-    assert_eq!(att.attester, attester);
-    assert_eq!(att.subject, subject);
+    assert_eq!(att.verifier, attester);
+    assert_eq!(att.identity, subject);
     assert_eq!(att.attestation_data, data);
     assert!(!att.revoked);
+    assert!(att.weight >= 1);
 }
 
 #[test]
@@ -140,9 +142,12 @@ fn test_add_multiple_attestations() {
 
     let subject = Address::generate(&e);
 
-    let att1 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att1"));
-    let att2 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att2"));
-    let att3 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att3"));
+    let n0 = client.get_nonce(&attester);
+    let att1 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att1"), &n0);
+    let n1 = client.get_nonce(&attester);
+    let att2 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att2"), &n1);
+    let n2 = client.get_nonce(&attester);
+    let att3 = client.add_attestation(&attester, &subject, &String::from_str(&e, "att3"), &n2);
 
     assert_eq!(att1.id, 0);
     assert_eq!(att2.id, 1);
@@ -168,11 +173,11 @@ fn test_add_attestation_different_attesters() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "verified");
 
-    let attestation1 = client.add_attestation(&att1, &subject, &data);
-    let attestation2 = client.add_attestation(&att2, &subject, &data);
+    let attestation1 = client.add_attestation(&att1, &subject, &data, &client.get_nonce(&att1));
+    let attestation2 = client.add_attestation(&att2, &subject, &data, &client.get_nonce(&att2));
 
-    assert_eq!(attestation1.attester, att1);
-    assert_eq!(attestation2.attester, att2);
+    assert_eq!(attestation1.verifier, att1);
+    assert_eq!(attestation2.verifier, att2);
     assert_ne!(attestation1.id, attestation2.id);
 }
 
@@ -194,11 +199,11 @@ fn test_add_attestation_different_subjects() {
     let sub2 = Address::generate(&e);
     let data = String::from_str(&e, "verified");
 
-    let att1 = client.add_attestation(&attester, &sub1, &data);
-    let att2 = client.add_attestation(&attester, &sub2, &data);
+    let att1 = client.add_attestation(&attester, &sub1, &data, &client.get_nonce(&attester));
+    let att2 = client.add_attestation(&attester, &sub2, &data, &client.get_nonce(&attester));
 
-    assert_eq!(att1.subject, sub1);
-    assert_eq!(att2.subject, sub2);
+    assert_eq!(att1.identity, sub1);
+    assert_eq!(att2.identity, sub2);
 }
 
 #[test]
@@ -218,7 +223,7 @@ fn test_add_attestation_empty_data() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "");
 
-    let att = client.add_attestation(&attester, &subject, &data);
+    let att = client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
     assert_eq!(att.attestation_data, data);
 }
 
@@ -242,7 +247,7 @@ fn test_unauthorized_attester_rejected() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "should fail");
 
-    client.add_attestation(&unauthorized, &subject, &data);
+    client.add_attestation(&unauthorized, &subject, &data, &0u64);
 }
 
 #[test]
@@ -261,11 +266,21 @@ fn test_unregistered_attester_cannot_attest() {
     client.register_attester(&attester);
 
     let subject = Address::generate(&e);
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "ok"));
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "ok"),
+        &client.get_nonce(&attester),
+    );
 
     client.unregister_attester(&attester);
 
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "should fail"));
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "should fail"),
+        &client.get_nonce(&attester),
+    );
 }
 
 // ============================================================================
@@ -289,10 +304,10 @@ fn test_revoke_attestation() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "to revoke");
 
-    let att = client.add_attestation(&attester, &subject, &data);
+    let att = client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
     assert!(!att.revoked);
 
-    client.revoke_attestation(&attester, &att.id);
+    client.revoke_attestation(&attester, &att.id, &client.get_nonce(&attester));
 
     let revoked = client.get_attestation(&att.id);
     assert!(revoked.revoked);
@@ -316,9 +331,14 @@ fn test_revoke_wrong_attester() {
     client.register_attester(&att2);
 
     let subject = Address::generate(&e);
-    let att = client.add_attestation(&att1, &subject, &String::from_str(&e, "test"));
+    let att = client.add_attestation(
+        &att1,
+        &subject,
+        &String::from_str(&e, "test"),
+        &client.get_nonce(&att1),
+    );
 
-    client.revoke_attestation(&att2, &att.id);
+    client.revoke_attestation(&att2, &att.id, &client.get_nonce(&att2));
 }
 
 #[test]
@@ -337,10 +357,15 @@ fn test_revoke_twice() {
     client.register_attester(&attester);
 
     let subject = Address::generate(&e);
-    let att = client.add_attestation(&attester, &subject, &String::from_str(&e, "test"));
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "test"),
+        &client.get_nonce(&attester),
+    );
 
-    client.revoke_attestation(&attester, &att.id);
-    client.revoke_attestation(&attester, &att.id);
+    client.revoke_attestation(&attester, &att.id, &client.get_nonce(&attester));
+    client.revoke_attestation(&attester, &att.id, &client.get_nonce(&attester));
 }
 
 #[test]
@@ -358,7 +383,7 @@ fn test_revoke_nonexistent() {
     let attester = Address::generate(&e);
     client.register_attester(&attester);
 
-    client.revoke_attestation(&attester, &999);
+    client.revoke_attestation(&attester, &999, &client.get_nonce(&attester));
 }
 
 // ============================================================================
@@ -366,7 +391,8 @@ fn test_revoke_nonexistent() {
 // ============================================================================
 
 #[test]
-fn test_duplicate_data_gets_unique_id() {
+#[should_panic(expected = "duplicate attestation")]
+fn test_duplicate_attestation_rejected() {
     let e = Env::default();
     e.mock_all_auths();
 
@@ -382,11 +408,40 @@ fn test_duplicate_data_gets_unique_id() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "duplicate");
 
-    let att1 = client.add_attestation(&attester, &subject, &data);
-    let att2 = client.add_attestation(&attester, &subject, &data);
+    let _att1 = client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
+    client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
+}
+
+#[test]
+fn test_same_attester_different_data_gets_unique_id() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, CredenceBond);
+    let client = CredenceBondClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let attester = Address::generate(&e);
+    client.register_attester(&attester);
+
+    let subject = Address::generate(&e);
+
+    let att1 = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "data1"),
+        &client.get_nonce(&attester),
+    );
+    let att2 = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "data2"),
+        &client.get_nonce(&attester),
+    );
 
     assert_ne!(att1.id, att2.id);
-    assert_eq!(att1.attestation_data, att2.attestation_data);
 }
 
 #[test]
@@ -405,12 +460,28 @@ fn test_same_attester_multiple_for_subject() {
 
     let subject = Address::generate(&e);
 
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "1"));
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "2"));
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "3"));
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "1"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "2"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "3"),
+        &client.get_nonce(&attester),
+    );
 
     let atts = client.get_subject_attestations(&subject);
     assert_eq!(atts.len(), 3);
+    assert_eq!(client.get_subject_attestation_count(&subject), 3);
 }
 
 // ============================================================================
@@ -432,8 +503,13 @@ fn test_events_published() {
     client.register_attester(&attester);
 
     let subject = Address::generate(&e);
-    let att = client.add_attestation(&attester, &subject, &String::from_str(&e, "test"));
-    client.revoke_attestation(&attester, &att.id);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "test"),
+        &client.get_nonce(&attester),
+    );
+    client.revoke_attestation(&attester, &att.id, &client.get_nonce(&attester));
 
     // Events are published during operations (verified by no panics)
     assert!(true);
@@ -460,12 +536,12 @@ fn test_get_attestation() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "get test");
 
-    let original = client.add_attestation(&attester, &subject, &data);
+    let original = client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
     let retrieved = client.get_attestation(&original.id);
 
     assert_eq!(retrieved.id, original.id);
-    assert_eq!(retrieved.attester, original.attester);
-    assert_eq!(retrieved.subject, original.subject);
+    assert_eq!(retrieved.verifier, original.verifier);
+    assert_eq!(retrieved.identity, original.identity);
     assert_eq!(retrieved.attestation_data, original.attestation_data);
 }
 
@@ -500,9 +576,24 @@ fn test_get_subject_attestations() {
 
     let subject = Address::generate(&e);
 
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "1"));
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "2"));
-    client.add_attestation(&attester, &subject, &String::from_str(&e, "3"));
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "1"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "2"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "3"),
+        &client.get_nonce(&attester),
+    );
 
     let atts = client.get_subject_attestations(&subject);
     assert_eq!(atts.len(), 3);
@@ -542,15 +633,32 @@ fn test_get_subject_attestations_different_subjects() {
     let sub1 = Address::generate(&e);
     let sub2 = Address::generate(&e);
 
-    client.add_attestation(&attester, &sub1, &String::from_str(&e, "s1_1"));
-    client.add_attestation(&attester, &sub1, &String::from_str(&e, "s1_2"));
-    client.add_attestation(&attester, &sub2, &String::from_str(&e, "s2_1"));
+    client.add_attestation(
+        &attester,
+        &sub1,
+        &String::from_str(&e, "s1_1"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &sub1,
+        &String::from_str(&e, "s1_2"),
+        &client.get_nonce(&attester),
+    );
+    client.add_attestation(
+        &attester,
+        &sub2,
+        &String::from_str(&e, "s2_1"),
+        &client.get_nonce(&attester),
+    );
 
     let s1_atts = client.get_subject_attestations(&sub1);
     let s2_atts = client.get_subject_attestations(&sub2);
 
     assert_eq!(s1_atts.len(), 2);
     assert_eq!(s2_atts.len(), 1);
+    assert_eq!(client.get_subject_attestation_count(&sub1), 2);
+    assert_eq!(client.get_subject_attestation_count(&sub2), 1);
 }
 
 // ============================================================================
@@ -571,9 +679,14 @@ fn test_self_attestation() {
     let address = Address::generate(&e);
     client.register_attester(&address);
 
-    let att = client.add_attestation(&address, &address, &String::from_str(&e, "self"));
+    let att = client.add_attestation(
+        &address,
+        &address,
+        &String::from_str(&e, "self"),
+        &client.get_nonce(&address),
+    );
 
-    assert_eq!(att.attester, att.subject);
+    assert_eq!(att.verifier, att.identity);
 }
 
 #[test]
@@ -591,10 +704,14 @@ fn test_timestamp_set() {
     client.register_attester(&attester);
 
     let subject = Address::generate(&e);
-    let att = client.add_attestation(&attester, &subject, &String::from_str(&e, "test"));
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "test"),
+        &client.get_nonce(&attester),
+    );
 
-    // Timestamp is u64, always >= 0
-    assert!(att.timestamp == e.ledger().timestamp());
+    assert_eq!(att.timestamp, e.ledger().timestamp());
 }
 
 #[test]
@@ -614,14 +731,14 @@ fn test_revoke_preserves_data() {
     let subject = Address::generate(&e);
     let data = String::from_str(&e, "preserved");
 
-    let original = client.add_attestation(&attester, &subject, &data);
-    client.revoke_attestation(&attester, &original.id);
+    let original = client.add_attestation(&attester, &subject, &data, &client.get_nonce(&attester));
+    client.revoke_attestation(&attester, &original.id, &client.get_nonce(&attester));
 
     let revoked = client.get_attestation(&original.id);
 
     assert_eq!(revoked.id, original.id);
-    assert_eq!(revoked.attester, original.attester);
-    assert_eq!(revoked.subject, original.subject);
+    assert_eq!(revoked.verifier, original.verifier);
+    assert_eq!(revoked.identity, original.identity);
     assert_eq!(revoked.attestation_data, original.attestation_data);
     assert_eq!(revoked.timestamp, original.timestamp);
     assert!(revoked.revoked);
@@ -651,14 +768,39 @@ fn test_complex_scenario() {
     let sub2 = Address::generate(&e);
 
     // Add attestations
-    let a1 = client.add_attestation(&att1, &sub1, &String::from_str(&e, "a1s1_1"));
-    let a2 = client.add_attestation(&att1, &sub1, &String::from_str(&e, "a1s1_2"));
-    let _a3 = client.add_attestation(&att2, &sub1, &String::from_str(&e, "a2s1"));
-    let _a4 = client.add_attestation(&att2, &sub2, &String::from_str(&e, "a2s2"));
-    let _a5 = client.add_attestation(&att3, &sub2, &String::from_str(&e, "a3s2"));
+    let a1 = client.add_attestation(
+        &att1,
+        &sub1,
+        &String::from_str(&e, "a1s1_1"),
+        &client.get_nonce(&att1),
+    );
+    let a2 = client.add_attestation(
+        &att1,
+        &sub1,
+        &String::from_str(&e, "a1s1_2"),
+        &client.get_nonce(&att1),
+    );
+    let _a3 = client.add_attestation(
+        &att2,
+        &sub1,
+        &String::from_str(&e, "a2s1"),
+        &client.get_nonce(&att2),
+    );
+    let _a4 = client.add_attestation(
+        &att2,
+        &sub2,
+        &String::from_str(&e, "a2s2"),
+        &client.get_nonce(&att2),
+    );
+    let _a5 = client.add_attestation(
+        &att3,
+        &sub2,
+        &String::from_str(&e, "a3s2"),
+        &client.get_nonce(&att3),
+    );
 
     // Revoke one
-    client.revoke_attestation(&att1, &a1.id);
+    client.revoke_attestation(&att1, &a1.id, &client.get_nonce(&att1));
 
     // Verify
     let s1_atts = client.get_subject_attestations(&sub1);

--- a/contracts/credence_bond/src/test_attestation_types.rs
+++ b/contracts/credence_bond/src/test_attestation_types.rs
@@ -1,0 +1,67 @@
+//! Tests for Attestation data structure: validation, serialization, and dedup key.
+
+#![cfg(test)]
+
+use crate::types::attestation::{DEFAULT_ATTESTATION_WEIGHT, MAX_ATTESTATION_WEIGHT};
+use crate::types::{Attestation, AttestationDedupKey};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Env, String};
+
+#[test]
+fn attestation_weight_validation_accepts_valid() {
+    Attestation::validate_weight(1);
+    Attestation::validate_weight(100);
+    Attestation::validate_weight(MAX_ATTESTATION_WEIGHT);
+}
+
+#[test]
+#[should_panic(expected = "attestation weight must be positive")]
+fn attestation_weight_validation_rejects_zero() {
+    Attestation::validate_weight(0);
+}
+
+#[test]
+#[should_panic(expected = "attestation weight exceeds maximum")]
+fn attestation_weight_validation_rejects_over_max() {
+    Attestation::validate_weight(MAX_ATTESTATION_WEIGHT + 1);
+}
+
+#[test]
+fn attestation_is_active() {
+    let e = Env::default();
+    let verifier = soroban_sdk::Address::generate(&e);
+    let identity = soroban_sdk::Address::generate(&e);
+    let data = String::from_str(&e, "data");
+    let att = Attestation {
+        id: 0,
+        verifier: verifier.clone(),
+        identity: identity.clone(),
+        timestamp: 0,
+        weight: DEFAULT_ATTESTATION_WEIGHT,
+        attestation_data: data,
+        revoked: false,
+    };
+    assert!(att.is_active());
+    let mut revoked = att.clone();
+    revoked.revoked = true;
+    assert!(!revoked.is_active());
+}
+
+#[test]
+fn attestation_dedup_key_equality() {
+    let e = Env::default();
+    let v = soroban_sdk::Address::generate(&e);
+    let i = soroban_sdk::Address::generate(&e);
+    let d = String::from_str(&e, "x");
+    let k1 = AttestationDedupKey {
+        verifier: v.clone(),
+        identity: i.clone(),
+        attestation_data: d.clone(),
+    };
+    let k2 = AttestationDedupKey {
+        verifier: v,
+        identity: i,
+        attestation_data: d,
+    };
+    assert_eq!(k1, k2);
+}

--- a/contracts/credence_bond/src/test_replay_prevention.rs
+++ b/contracts/credence_bond/src/test_replay_prevention.rs
@@ -1,0 +1,90 @@
+//! Tests for replay attack prevention: nonce validation and rejection of replayed transactions.
+
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Env, String};
+
+fn setup(e: &Env) -> (CredenceBondClient, soroban_sdk::Address) {
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CredenceBond);
+    let client = CredenceBondClient::new(e, &contract_id);
+    let admin = soroban_sdk::Address::generate(e);
+    client.initialize(&admin);
+    let attester = soroban_sdk::Address::generate(e);
+    client.register_attester(&attester);
+    (client, attester)
+}
+
+#[test]
+fn nonce_starts_at_zero() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    assert_eq!(client.get_nonce(&attester), 0);
+}
+
+#[test]
+fn nonce_increments_after_add_attestation() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    assert_eq!(client.get_nonce(&attester), 0);
+    client.add_attestation(&attester, &subject, &String::from_str(&e, "d"), &0u64);
+    assert_eq!(client.get_nonce(&attester), 1);
+    client.add_attestation(&attester, &subject, &String::from_str(&e, "d2"), &1u64);
+    assert_eq!(client.get_nonce(&attester), 2);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn replay_add_attestation_rejected() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let data = String::from_str(&e, "once");
+    client.add_attestation(&attester, &subject, &data, &0u64);
+    client.add_attestation(&attester, &subject, &data, &0u64);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn wrong_nonce_rejected() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    client.add_attestation(&attester, &subject, &String::from_str(&e, "x"), &1u64);
+}
+
+#[test]
+fn nonce_increments_after_revoke() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "rev"),
+        &client.get_nonce(&attester),
+    );
+    let nonce_before = client.get_nonce(&attester);
+    client.revoke_attestation(&attester, &att.id, &nonce_before);
+    assert_eq!(client.get_nonce(&attester), nonce_before + 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn replay_revoke_rejected() {
+    let e = Env::default();
+    let (client, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "r"),
+        &client.get_nonce(&attester),
+    );
+    let used_nonce = client.get_nonce(&attester) - 1;
+    client.revoke_attestation(&attester, &att.id, &used_nonce);
+    client.revoke_attestation(&attester, &att.id, &used_nonce);
+}

--- a/contracts/credence_bond/src/test_weighted_attestation.rs
+++ b/contracts/credence_bond/src/test_weighted_attestation.rs
@@ -1,0 +1,80 @@
+//! Tests for weighted attestation: weight from attester stake, config, cap.
+
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Env, String};
+
+fn setup(
+    e: &Env,
+) -> (
+    CredenceBondClient,
+    soroban_sdk::Address,
+    soroban_sdk::Address,
+) {
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CredenceBond);
+    let client = CredenceBondClient::new(e, &contract_id);
+    let admin = soroban_sdk::Address::generate(e);
+    client.initialize(&admin);
+    let attester = soroban_sdk::Address::generate(e);
+    client.register_attester(&attester);
+    (client, admin, attester)
+}
+
+#[test]
+fn default_weight_is_one() {
+    let e = Env::default();
+    let (client, _admin, attester) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "data"),
+        &client.get_nonce(&attester),
+    );
+    assert_eq!(att.weight, 1);
+}
+
+#[test]
+fn weight_increases_with_stake() {
+    let e = Env::default();
+    let (client, admin, attester) = setup(&e);
+    client.set_attester_stake(&admin, &attester, &1_000_000i128);
+    client.set_weight_config(&admin, &100u32, &100_000u32);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "data"),
+        &client.get_nonce(&attester),
+    );
+    assert!(att.weight >= 1);
+}
+
+#[test]
+fn weight_capped_by_config() {
+    let e = Env::default();
+    let (client, admin, attester) = setup(&e);
+    client.set_attester_stake(&admin, &attester, &1_000_000_000_000i128);
+    client.set_weight_config(&admin, &100_000u32, &500u32);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "capped"),
+        &client.get_nonce(&attester),
+    );
+    assert!(att.weight <= 500);
+}
+
+#[test]
+fn get_weight_config_returns_set_values() {
+    let e = Env::default();
+    let (client, admin, _attester) = setup(&e);
+    client.set_weight_config(&admin, &200u32, &10_000u32);
+    let (mult, max) = client.get_weight_config();
+    assert_eq!(mult, 200);
+    assert_eq!(max, 10_000);
+}

--- a/contracts/credence_bond/src/types/attestation.rs
+++ b/contracts/credence_bond/src/types/attestation.rs
@@ -1,0 +1,71 @@
+//! Attestation data structure and validation.
+//!
+//! Defines the Attestation type used for credibility attestations: verifier (attester),
+//! subject (identity), timestamp, weight. Supports serialization via ContractType
+//! and validation methods for storage efficiency and safety.
+
+use soroban_sdk::{contracttype, Address, String};
+
+/// Maximum allowed attestation weight (prevents overflow and caps influence).
+pub const MAX_ATTESTATION_WEIGHT: u32 = 1_000_000;
+
+/// Default weight when attester has no stake configured.
+pub const DEFAULT_ATTESTATION_WEIGHT: u32 = 1;
+
+/// Attestation record: a verifier's credibility attestation for an identity.
+///
+/// # Fields
+/// * `id` - Unique attestation identifier.
+/// * `verifier` - Address of the authorized attester (verifier).
+/// * `identity` - Address of the subject (identity) being attested.
+/// * `timestamp` - Ledger timestamp when the attestation was added.
+/// * `weight` - Credibility weight (e.g. derived from attester bond); capped by protocol.
+/// * `attestation_data` - Opaque attestation payload (e.g. claim type or hash).
+/// * `revoked` - Whether this attestation has been revoked.
+///
+/// # Serialization
+/// Uses `#[contracttype]` for Soroban instance storage; space-efficient (u64, u32, bool, Address, String).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    pub id: u64,
+    pub verifier: Address,
+    pub identity: Address,
+    pub timestamp: u64,
+    pub weight: u32,
+    pub attestation_data: String,
+    pub revoked: bool,
+}
+
+impl Attestation {
+    /// Validates that weight is within allowed bounds.
+    ///
+    /// # Errors
+    /// Panics if `weight` is zero or exceeds `MAX_ATTESTATION_WEIGHT`.
+    #[inline]
+    pub fn validate_weight(weight: u32) {
+        if weight == 0 {
+            panic!("attestation weight must be positive");
+        }
+        if weight > MAX_ATTESTATION_WEIGHT {
+            panic!("attestation weight exceeds maximum");
+        }
+    }
+
+    /// Returns true if this attestation is currently active (not revoked).
+    #[must_use]
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        !self.revoked
+    }
+}
+
+/// Key used to detect duplicate attestations: same verifier, identity, and data.
+/// Stored in instance storage to prevent adding the same attestation twice.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationDedupKey {
+    pub verifier: Address,
+    pub identity: Address,
+    pub attestation_data: String,
+}

--- a/contracts/credence_bond/src/types/mod.rs
+++ b/contracts/credence_bond/src/types/mod.rs
@@ -1,0 +1,7 @@
+//! Protocol data types for bonds and attestations.
+//!
+//! Includes Attestation (with weight), validation, and deduplication key types.
+
+pub mod attestation;
+
+pub use attestation::{Attestation, AttestationDedupKey};

--- a/contracts/credence_bond/src/weighted_attestation.rs
+++ b/contracts/credence_bond/src/weighted_attestation.rs
@@ -1,0 +1,77 @@
+//! Weighted attestation system: attestation value depends on attester's credibility.
+//!
+//! Weight is derived from the attester's bond (or configured stake), with
+//! a configurable multiplier and a protocol cap. When attester bond changes,
+//! new attestations use the new weight; existing attestations retain their stored weight.
+
+use soroban_sdk::Env;
+
+use crate::types::attestation::MAX_ATTESTATION_WEIGHT;
+use crate::DataKey;
+
+/// Default weight multiplier in basis points (1 = 0.01%). weight = stake * multiplier_bps / 10_000.
+pub const DEFAULT_WEIGHT_MULTIPLIER_BPS: u32 = 100;
+
+/// Default maximum attestation weight when no config is set.
+pub const DEFAULT_MAX_WEIGHT: u32 = 100_000;
+
+/// Storage key for weight config (multiplier bps, max weight). Stored as (u32, u32).
+fn weight_config_key(e: &Env) -> soroban_sdk::Symbol {
+    soroban_sdk::Symbol::new(e, "weight_cfg")
+}
+
+/// Returns (multiplier_bps, max_weight). Uses defaults if not set.
+#[must_use]
+pub fn get_weight_config(e: &Env) -> (u32, u32) {
+    e.storage()
+        .instance()
+        .get::<_, (u32, u32)>(&weight_config_key(e))
+        .unwrap_or((DEFAULT_WEIGHT_MULTIPLIER_BPS, DEFAULT_MAX_WEIGHT))
+}
+
+/// Sets weight config (admin only; caller must enforce). multiplier_bps in basis points, max_weight capped by MAX_ATTESTATION_WEIGHT.
+pub fn set_weight_config(e: &Env, multiplier_bps: u32, max_weight: u32) {
+    let cap = core::cmp::min(max_weight, MAX_ATTESTATION_WEIGHT);
+    e.storage()
+        .instance()
+        .set(&weight_config_key(e), &(multiplier_bps, cap));
+}
+
+/// Returns the attester's stake (bond amount or configured stake). 0 if not set.
+#[must_use]
+pub fn get_attester_stake(e: &Env, attester: &soroban_sdk::Address) -> i128 {
+    e.storage()
+        .instance()
+        .get(&DataKey::AttesterStake(attester.clone()))
+        .unwrap_or(0)
+}
+
+/// Sets attester stake (e.g. from bond). Caller must be admin.
+pub fn set_attester_stake(e: &Env, attester: &soroban_sdk::Address, amount: i128) {
+    if amount < 0 {
+        panic!("attester stake cannot be negative");
+    }
+    e.storage()
+        .instance()
+        .set(&DataKey::AttesterStake(attester.clone()), &amount);
+}
+
+/// Computes attestation weight from attester stake using config. Capped by config max and MAX_ATTESTATION_WEIGHT.
+/// If stake is 0, returns default weight (1) so attestations are still allowed.
+#[must_use]
+pub fn compute_weight(e: &Env, attester: &soroban_sdk::Address) -> u32 {
+    use crate::types::attestation::DEFAULT_ATTESTATION_WEIGHT;
+
+    let stake = get_attester_stake(e, attester);
+    let (multiplier_bps, max_weight) = get_weight_config(e);
+
+    if stake <= 0 {
+        return DEFAULT_ATTESTATION_WEIGHT;
+    }
+
+    // weight = (stake * multiplier_bps / 10_000) capped at max_weight and MAX_ATTESTATION_WEIGHT
+    let stake_u64 = stake.unsigned_abs() as u64;
+    let w = (stake_u64 * (multiplier_bps as u64) / 10_000) as u32;
+    let capped = core::cmp::min(w, max_weight);
+    core::cmp::min(capped, MAX_ATTESTATION_WEIGHT).max(DEFAULT_ATTESTATION_WEIGHT)
+}

--- a/docs/attestations.md
+++ b/docs/attestations.md
@@ -1,0 +1,43 @@
+# Attestations
+
+Verifiers add credibility attestations to identity bonds. Only authorized attesters can add or revoke attestations; each attestation has a weight, timestamp, and is deduplicated and replay-protected.
+
+## Data structure
+
+- **Attestation** — `id`, `verifier` (attester address), `identity` (subject address), `timestamp`, `weight`, `attestation_data`, `revoked`. Stored by ID; dedup key is (verifier, identity, attestation_data).
+- **Subject attestation count** — O(1) count per identity, updated on add/revoke.
+
+## Authorization
+
+- **register_attester(attester)** — Admin only. Registers an authorized verifier.
+- **unregister_attester(attester)** — Admin only.
+- **is_attester(attester)** — Returns whether the address is an authorized attester.
+
+## Adding attestations
+
+- **add_attestation(attester, subject, attestation_data, nonce)**  
+  - Caller must be the attester (require_auth).  
+  - Attester must be registered.  
+  - Nonce must match current attester nonce (replay prevention); nonce is incremented on success.  
+  - Duplicate (same verifier, identity, attestation_data) is rejected.  
+  - Weight is computed from attester stake (see weighted attestations).  
+  - Emits `attestation_added` with (subject, id, attester, attestation_data, weight).
+
+## Revoking attestations
+
+- **revoke_attestation(attester, attestation_id, nonce)**  
+  - Only the original verifier can revoke. Nonce consumed and incremented.  
+  - Subject attestation count is decremented; dedup key is removed so the same triple can be attested again.  
+  - Emits `attestation_revoked`.
+
+## Queries
+
+- **get_attestation(attestation_id)** — Returns the attestation or panics if not found.
+- **get_subject_attestations(subject)** — Returns list of attestation IDs for the identity.
+- **get_subject_attestation_count(subject)** — Returns the active attestation count for the identity.
+
+## Security
+
+- Verifier must be authorized and pass require_auth.
+- Duplicate attestations (same verifier, identity, data) are prevented.
+- Replay is prevented via per-identity nonces; see security.md.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,21 @@
+# Security
+
+Security mechanisms for the Credence bond and attestation system.
+
+## Replay attack prevention
+
+- **Nonces** — Each identity has a nonce (starts at 0). State-changing attestation calls require the current nonce and increment it on success.
+- **get_nonce(identity)** — Returns the current nonce; the caller must pass this value in the next add_attestation or revoke_attestation call.
+- Replayed or out-of-order transactions are rejected with "invalid nonce" because the stored nonce no longer matches.
+- Nonce overflow is handled by checked arithmetic (panic if increment would overflow).
+
+## Attestation security
+
+- Only registered attesters can add attestations; attester must pass require_auth.
+- Duplicate attestations (same verifier, identity, attestation_data) are rejected.
+- Revocation is restricted to the original verifier; nonce is required for revoke.
+
+## Bond and reentrancy
+
+- Reentrancy guard is used in withdraw_bond, slash_bond, and collect_fees; state is updated before any external call (checks-effects-interactions).
+- See contract code for lock acquire/release around callbacks.

--- a/docs/weighted-attestations.md
+++ b/docs/weighted-attestations.md
@@ -1,0 +1,23 @@
+# Weighted attestations
+
+Attestation value depends on the attester's credibility (stake). Weight is derived from attester stake with a configurable multiplier and cap.
+
+## Config
+
+- **set_weight_config(admin, multiplier_bps, max_weight)** — Admin only. `multiplier_bps` is in basis points (e.g. 100 = 1%); weight = stake * multiplier_bps / 10_000, capped at `max_weight` and at protocol MAX_ATTESTATION_WEIGHT.
+- **get_weight_config()** — Returns (multiplier_bps, max_weight).
+
+## Attester stake
+
+- **set_attester_stake(admin, attester, amount)** — Admin only. Sets the stake used to compute attestation weight for that attester. Can reflect bond amount or delegated credibility.
+- If no stake is set, attestations use default weight 1.
+
+## Weight computation
+
+- When adding an attestation, weight = min(stake * multiplier_bps / 10_000, max_weight, MAX_ATTESTATION_WEIGHT), with a minimum of 1.
+- Existing attestations keep their stored weight; when attester stake or config changes, only new attestations use the new weight.
+
+## Security
+
+- Weight is capped to prevent a single high-stake attester from dominating.
+- Negative stake is rejected in set_attester_stake.


### PR DESCRIPTION
- Added nonce handling to prevent replay attacks, requiring a nonce for state-changing calls.
- Introduced weighted attestation, where attestation weight is derived from attester stake with configurable multipliers and caps.
- Updated the Attestation structure to include weight and added validation methods.
- Implemented tests for nonce functionality, attestation weight validation, and replay prevention.
- Enhanced documentation for attestations and security measures.

Closes #8 #10 #11 #24