### PR TITLE
test: add validation tests for attestation weight limits

### DIFF
--- a/contracts/credence_bond/src/test_attestation_types.rs
+++ b/contracts/credence_bond/src/test_attestation_types.rs
@@ -27,6 +27,53 @@ fn attestation_weight_validation_rejects_over_max() {
 }
 
 #[test]
+fn attestation_validate_accepts_valid() {
+    let e = Env::default();
+    let att = Attestation {
+        id: 0,
+        verifier: soroban_sdk::Address::generate(&e),
+        identity: soroban_sdk::Address::generate(&e),
+        timestamp: 0,
+        weight: DEFAULT_ATTESTATION_WEIGHT,
+        attestation_data: String::from_str(&e, "x"),
+        revoked: false,
+    };
+    att.validate();
+}
+
+#[test]
+#[should_panic(expected = "attestation weight must be positive")]
+fn attestation_validate_rejects_zero_weight() {
+    let e = Env::default();
+    let att = Attestation {
+        id: 0,
+        verifier: soroban_sdk::Address::generate(&e),
+        identity: soroban_sdk::Address::generate(&e),
+        timestamp: 0,
+        weight: 0,
+        attestation_data: String::from_str(&e, "x"),
+        revoked: false,
+    };
+    att.validate();
+}
+
+#[test]
+#[should_panic(expected = "attestation weight exceeds maximum")]
+fn attestation_validate_rejects_over_max_weight() {
+    let e = Env::default();
+    let att = Attestation {
+        id: 0,
+        verifier: soroban_sdk::Address::generate(&e),
+        identity: soroban_sdk::Address::generate(&e),
+        timestamp: 0,
+        weight: MAX_ATTESTATION_WEIGHT + 1,
+        attestation_data: String::from_str(&e, "x"),
+        revoked: false,
+    };
+    att.validate();
+}
+
+#[test]
 fn attestation_is_active() {
     let e = Env::default();
     let verifier = soroban_sdk::Address::generate(&e);
@@ -64,4 +111,17 @@ fn attestation_dedup_key_equality() {
         attestation_data: d,
     };
     assert_eq!(k1, k2);
+}
+
+/// Serialization is exercised via add_attestation/get_attestation (contract storage) in test_attestation.
+/// Attestation and AttestationDedupKey use #[contracttype] for Soroban instance storage.
+
+#[test]
+fn attestation_boundary_weight_max() {
+    Attestation::validate_weight(MAX_ATTESTATION_WEIGHT);
+}
+
+#[test]
+fn attestation_boundary_weight_min() {
+    Attestation::validate_weight(1);
 }

--- a/contracts/credence_bond/src/test_weighted_attestation.rs
+++ b/contracts/credence_bond/src/test_weighted_attestation.rs
@@ -2,6 +2,8 @@
 
 #![cfg(test)]
 
+use crate::types::attestation::MAX_ATTESTATION_WEIGHT;
+use crate::weighted_attestation;
 use crate::*;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Env, String};
@@ -77,4 +79,103 @@ fn get_weight_config_returns_set_values() {
     let (mult, max) = client.get_weight_config();
     assert_eq!(mult, 200);
     assert_eq!(max, 10_000);
+}
+
+#[test]
+fn get_attester_stake_default_zero() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CredenceBond);
+    let client = CredenceBondClient::new(&e, &contract_id);
+    let admin = soroban_sdk::Address::generate(&e);
+    client.initialize(&admin);
+    let attester = soroban_sdk::Address::generate(&e);
+    client.register_attester(&attester);
+    let stake = e.as_contract(&contract_id, || {
+        weighted_attestation::get_attester_stake(&e, &attester)
+    });
+    assert_eq!(stake, 0);
+}
+
+#[test]
+fn compute_weight_zero_stake_returns_default() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CredenceBond);
+    let _client = CredenceBondClient::new(&e, &contract_id);
+    let attester = soroban_sdk::Address::generate(&e);
+    let w = e.as_contract(&contract_id, || {
+        weighted_attestation::compute_weight(&e, &attester)
+    });
+    assert_eq!(w, 1);
+}
+
+#[test]
+#[should_panic(expected = "attester stake cannot be negative")]
+fn set_attester_stake_negative_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CredenceBond);
+    let client = CredenceBondClient::new(&e, &contract_id);
+    let admin = soroban_sdk::Address::generate(&e);
+    client.initialize(&admin);
+    let attester = soroban_sdk::Address::generate(&e);
+    client.set_attester_stake(&admin, &attester, &(-1i128));
+}
+
+#[test]
+fn weight_capped_by_max_attestation_weight() {
+    let e = Env::default();
+    let (client, admin, attester) = setup(&e);
+    // Use stake high enough to exceed MAX_ATTESTATION_WEIGHT but avoid overflow: 200M * 100 / 10_000 = 2M
+    client.set_attester_stake(&admin, &attester, &200_000_000i128);
+    let max_requested = MAX_ATTESTATION_WEIGHT + 1000u32;
+    client.set_weight_config(&admin, &100u32, &max_requested);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "max_cap"),
+        &client.get_nonce(&attester),
+    );
+    assert!(att.weight <= MAX_ATTESTATION_WEIGHT);
+}
+
+#[test]
+fn weight_updates_when_stake_changes() {
+    let e = Env::default();
+    let (client, admin, attester) = setup(&e);
+    client.set_weight_config(&admin, &100u32, &100_000u32);
+
+    client.set_attester_stake(&admin, &attester, &10_000i128);
+    let subject = soroban_sdk::Address::generate(&e);
+    let att1 = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "first"),
+        &client.get_nonce(&attester),
+    );
+
+    client.set_attester_stake(&admin, &attester, &1_000_000i128);
+    let att2 = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "second"),
+        &client.get_nonce(&attester),
+    );
+
+    assert!(
+        att2.weight > att1.weight,
+        "weight should increase when stake increases"
+    );
+}
+
+#[test]
+fn set_weight_config_caps_max_at_protocol_limit() {
+    let e = Env::default();
+    let (client, admin, _attester) = setup(&e);
+    let max_requested = MAX_ATTESTATION_WEIGHT + 5000u32;
+    client.set_weight_config(&admin, &100u32, &max_requested);
+    let (_mult, max) = client.get_weight_config();
+    assert_eq!(max, MAX_ATTESTATION_WEIGHT);
 }

--- a/contracts/credence_bond/src/types/attestation.rs
+++ b/contracts/credence_bond/src/types/attestation.rs
@@ -52,6 +52,15 @@ impl Attestation {
         }
     }
 
+    /// Validates this attestation (weight bounds). Use after deserialization or before storage.
+    ///
+    /// # Errors
+    /// Panics if `self.weight` is zero or exceeds `MAX_ATTESTATION_WEIGHT`.
+    #[inline]
+    pub fn validate(&self) {
+        Self::validate_weight(self.weight);
+    }
+
     /// Returns true if this attestation is currently active (not revoked).
     #[must_use]
     #[inline]

--- a/contracts/credence_bond/src/types/mod.rs
+++ b/contracts/credence_bond/src/types/mod.rs
@@ -4,4 +4,6 @@
 
 pub mod attestation;
 
-pub use attestation::{Attestation, AttestationDedupKey};
+pub use attestation::{
+    Attestation, AttestationDedupKey, DEFAULT_ATTESTATION_WEIGHT, MAX_ATTESTATION_WEIGHT,
+};

--- a/contracts/credence_bond/src/weighted_attestation.rs
+++ b/contracts/credence_bond/src/weighted_attestation.rs
@@ -1,21 +1,27 @@
 //! Weighted attestation system: attestation value depends on attester's credibility.
 //!
-//! Weight is derived from the attester's bond (or configured stake), with
-//! a configurable multiplier and a protocol cap. When attester bond changes,
+//! ## Overview
+//! Attestation weight is derived from the attester's bond (or configured stake), with
+//! a configurable multiplier (basis points) and a protocol cap. When attester bond changes,
 //! new attestations use the new weight; existing attestations retain their stored weight.
+//!
+//! ## Security
+//! - Maximum weight is capped by `MAX_ATTESTATION_WEIGHT` to limit influence.
+//! - Negative stake is rejected in `set_attester_stake`.
+//! - Weight config is admin-only (enforced by contract entrypoints).
 
 use soroban_sdk::Env;
 
 use crate::types::attestation::MAX_ATTESTATION_WEIGHT;
 use crate::DataKey;
 
-/// Default weight multiplier in basis points (1 = 0.01%). weight = stake * multiplier_bps / 10_000.
+/// Default weight multiplier in basis points (1 = 0.01%). Formula: weight = stake * multiplier_bps / 10_000.
 pub const DEFAULT_WEIGHT_MULTIPLIER_BPS: u32 = 100;
 
 /// Default maximum attestation weight when no config is set.
 pub const DEFAULT_MAX_WEIGHT: u32 = 100_000;
 
-/// Storage key for weight config (multiplier bps, max weight). Stored as (u32, u32).
+/// Storage key for weight config (multiplier_bps, max weight). Stored as (u32, u32).
 fn weight_config_key(e: &Env) -> soroban_sdk::Symbol {
     soroban_sdk::Symbol::new(e, "weight_cfg")
 }
@@ -29,7 +35,8 @@ pub fn get_weight_config(e: &Env) -> (u32, u32) {
         .unwrap_or((DEFAULT_WEIGHT_MULTIPLIER_BPS, DEFAULT_MAX_WEIGHT))
 }
 
-/// Sets weight config (admin only; caller must enforce). multiplier_bps in basis points, max_weight capped by MAX_ATTESTATION_WEIGHT.
+/// Sets weight config (admin only; caller must enforce). multiplier_bps in basis points;
+/// max_weight is capped by MAX_ATTESTATION_WEIGHT.
 pub fn set_weight_config(e: &Env, multiplier_bps: u32, max_weight: u32) {
     let cap = core::cmp::min(max_weight, MAX_ATTESTATION_WEIGHT);
     e.storage()
@@ -46,7 +53,10 @@ pub fn get_attester_stake(e: &Env, attester: &soroban_sdk::Address) -> i128 {
         .unwrap_or(0)
 }
 
-/// Sets attester stake (e.g. from bond). Caller must be admin.
+/// Sets attester stake (e.g. from bond). Caller must be admin. Rejects negative amount.
+///
+/// # Errors
+/// Panics if amount < 0.
 pub fn set_attester_stake(e: &Env, attester: &soroban_sdk::Address, amount: i128) {
     if amount < 0 {
         panic!("attester stake cannot be negative");
@@ -56,8 +66,8 @@ pub fn set_attester_stake(e: &Env, attester: &soroban_sdk::Address, amount: i128
         .set(&DataKey::AttesterStake(attester.clone()), &amount);
 }
 
-/// Computes attestation weight from attester stake using config. Capped by config max and MAX_ATTESTATION_WEIGHT.
-/// If stake is 0, returns default weight (1) so attestations are still allowed.
+/// Computes attestation weight from attester stake using config. Capped by config max and
+/// MAX_ATTESTATION_WEIGHT. If stake is 0, returns default weight (1) so attestations are still allowed.
 #[must_use]
 pub fn compute_weight(e: &Env, attester: &soroban_sdk::Address) -> u32 {
     use crate::types::attestation::DEFAULT_ATTESTATION_WEIGHT;


### PR DESCRIPTION
## Summary
Implements the Attestation data structure (issue #10) and the Weighted Attestation System (issue #11) as specified in the protocol design.

## Issue #10 – Attestation data structure
- **Types** (`types/attestation.rs`): `Attestation` with `verifier`, `identity`, `timestamp`, `weight`, plus `id`, `attestation_data`, `revoked`. `AttestationDedupKey` for duplicate detection.
- **Serialization**: `#[contracttype]` for Soroban instance storage; space-efficient layout.
- **Validation**: `validate_weight(u32)`, `validate(&self)`, `is_active(&self)`.
- **Constants**: `MAX_ATTESTATION_WEIGHT`, `DEFAULT_ATTESTATION_WEIGHT`; re-exported from `types`.
- **Documentation**: NatSpec-style module and field comments.
- **Tests** (`test_attestation_types.rs`): weight validation (valid, zero, over max), full `validate()`, `is_active`, dedup key equality, boundary weights. Serialization covered via add/get attestation in existing tests.

## Issue #11 – Weighted attestation system
- **Logic** (`weighted_attestation.rs`): attestation weight from attester stake; configurable multiplier (bps) and max weight; cap at `MAX_ATTESTATION_WEIGHT`.
- **API**: `get_weight_config` / `set_weight_config`, `get_attester_stake` / `set_attester_stake`, `compute_weight(env, attester)`.
- **Security**: Negative stake rejected; max weight capped by protocol; config/admin behavior documented.
- **Documentation**: Module overview, security notes, and function-level NatSpec-style comments.
- **Tests** (`test_weighted_attestation.rs`): default weight when no stake, weight from stake, config cap, protocol cap, stake change updates weight, negative stake panic, default zero stake, config caps at protocol limit.

## CI
- `cargo fmt --all -- --check`
- `cargo build --all-targets`
- `cargo test --all-targets`

All pass.