### PR TITLE
feat(contracts): add events for critical config updates

### DIFF
--- a/contracts/credence_bond/src/pausable.rs
+++ b/contracts/credence_bond/src/pausable.rs
@@ -38,10 +38,10 @@ pub fn set_pause_signer(e: &Env, admin: &Address, signer: &Address, enabled: boo
     require_admin_auth(e, admin);
 
     let key = DataKey::PauseSigner(signer.clone());
-    let existing: bool = e.storage().instance().get(&key).unwrap_or(false);
+    let old_enabled: bool = e.storage().instance().get(&key).unwrap_or(false);
 
     if enabled {
-        if !existing {
+        if !old_enabled {
             e.storage().instance().set(&key, &true);
             let count: u32 = e
                 .storage()
@@ -52,7 +52,7 @@ pub fn set_pause_signer(e: &Env, admin: &Address, signer: &Address, enabled: boo
                 .instance()
                 .set(&DataKey::PauseSignerCount, &count.saturating_add(1));
         }
-    } else if existing {
+    } else if old_enabled {
         e.storage().instance().remove(&key);
         let count: u32 = e
             .storage()
@@ -80,9 +80,10 @@ pub fn set_pause_signer(e: &Env, admin: &Address, signer: &Address, enabled: boo
         }
     }
 
+    // Emit old and new values for auditability
     e.events().publish(
         (Symbol::new(e, "pause_signer_set"), signer.clone()),
-        enabled,
+        (old_enabled, enabled),
     );
 }
 
@@ -96,11 +97,18 @@ pub fn set_pause_threshold(e: &Env, admin: &Address, threshold: u32) {
     if threshold > count {
         panic!("threshold cannot exceed signer count");
     }
+    let old_threshold: u32 = e
+        .storage()
+        .instance()
+        .get(&DataKey::PauseThreshold)
+        .unwrap_or(0);
     e.storage()
         .instance()
         .set(&DataKey::PauseThreshold, &threshold);
+
+    // Emit old and new values for auditability
     e.events()
-        .publish((Symbol::new(e, "pause_threshold_set"),), threshold);
+        .publish((Symbol::new(e, "pause_threshold_set"),), (old_threshold, threshold));
 }
 
 fn require_pause_signer(e: &Env, signer: &Address) {

--- a/contracts/credence_bond/src/test_parameters.rs
+++ b/contracts/credence_bond/src/test_parameters.rs
@@ -719,3 +719,145 @@ fn test_max_values_for_all_parameters() {
     assert_eq!(client.get_gold_threshold(), MAX_GOLD_THRESHOLD);
     assert_eq!(client.get_platinum_threshold(), MAX_PLATINUM_THRESHOLD);
 }
+
+// ============================================================================
+// Category 10: Event Argument Verification (issue #138)
+// ============================================================================
+
+#[test]
+fn test_protocol_fee_event_args() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    // Set to 100 first so old_value is known
+    client.set_protocol_fee_bps(&admin, &100);
+    // Now update: old=100, new=200
+    client.set_protocol_fee_bps(&admin, &200);
+
+    let events = e.events().all();
+    // Find the last parameter_changed event
+    let last = events.iter().rev().find(|(_, topics, _)| {
+        if let soroban_sdk::Val::Symbol(s) = topics.get(0).unwrap() {
+            s == soroban_sdk::Symbol::new(&e, "parameter_changed")
+        } else {
+            false
+        }
+    });
+    assert!(last.is_some(), "parameter_changed event not emitted");
+    let (_, _, data) = last.unwrap();
+    // data = (parameter_name, old_value, new_value, caller, timestamp)
+    let (_, old_val, new_val, _, _): (soroban_sdk::String, i128, i128, Address, u64) =
+        data.into_val(&e);
+    assert_eq!(old_val, 100i128, "old_value mismatch");
+    assert_eq!(new_val, 200i128, "new_value mismatch");
+}
+
+#[test]
+fn test_attestation_fee_event_args() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    client.set_attestation_fee_bps(&admin, &25);
+    client.set_attestation_fee_bps(&admin, &50);
+
+    let events = e.events().all();
+    let last = events.iter().rev().find(|(_, topics, _)| {
+        if let soroban_sdk::Val::Symbol(s) = topics.get(0).unwrap() {
+            s == soroban_sdk::Symbol::new(&e, "parameter_changed")
+        } else {
+            false
+        }
+    });
+    assert!(last.is_some(), "parameter_changed event not emitted");
+    let (_, _, data) = last.unwrap();
+    let (_, old_val, new_val, _, _): (soroban_sdk::String, i128, i128, Address, u64) =
+        data.into_val(&e);
+    assert_eq!(old_val, 25i128);
+    assert_eq!(new_val, 50i128);
+}
+
+#[test]
+fn test_withdrawal_cooldown_event_args() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    client.set_withdrawal_cooldown_secs(&admin, &3600);
+    client.set_withdrawal_cooldown_secs(&admin, &7200);
+
+    let events = e.events().all();
+    let last = events.iter().rev().find(|(_, topics, _)| {
+        if let soroban_sdk::Val::Symbol(s) = topics.get(0).unwrap() {
+            s == soroban_sdk::Symbol::new(&e, "parameter_changed")
+        } else {
+            false
+        }
+    });
+    assert!(last.is_some());
+    let (_, _, data) = last.unwrap();
+    let (_, old_val, new_val, _, _): (soroban_sdk::String, i128, i128, Address, u64) =
+        data.into_val(&e);
+    assert_eq!(old_val, 3600i128);
+    assert_eq!(new_val, 7200i128);
+}
+
+#[test]
+fn test_pause_signer_event_includes_old_and_new() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    let signer = Address::generate(&e);
+
+    // Enable signer: old=false, new=true
+    client.set_pause_signer(&admin, &signer, &true);
+
+    let events = e.events().all();
+    let ev = events.iter().rev().find(|(_, topics, _)| {
+        if let soroban_sdk::Val::Symbol(s) = topics.get(0).unwrap() {
+            s == soroban_sdk::Symbol::new(&e, "pause_signer_set")
+        } else {
+            false
+        }
+    });
+    assert!(ev.is_some(), "pause_signer_set event not emitted");
+    let (_, _, data) = ev.unwrap();
+    let (old_val, new_val): (bool, bool) = data.into_val(&e);
+    assert!(!old_val, "old_enabled should be false");
+    assert!(new_val, "new_enabled should be true");
+}
+
+#[test]
+fn test_pause_threshold_event_includes_old_and_new() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    let signer = Address::generate(&e);
+
+    // Add signer first so threshold can be set to 1
+    client.set_pause_signer(&admin, &signer, &true);
+    client.set_pause_threshold(&admin, &1);
+
+    let events = e.events().all();
+    let ev = events.iter().rev().find(|(_, topics, _)| {
+        if let soroban_sdk::Val::Symbol(s) = topics.get(0).unwrap() {
+            s == soroban_sdk::Symbol::new(&e, "pause_threshold_set")
+        } else {
+            false
+        }
+    });
+    assert!(ev.is_some(), "pause_threshold_set event not emitted");
+    let (_, _, data) = ev.unwrap();
+    let (old_val, new_val): (u32, u32) = data.into_val(&e);
+    assert_eq!(old_val, 0u32, "old threshold should be 0");
+    assert_eq!(new_val, 1u32, "new threshold should be 1");
+}
+
+#[test]
+fn test_no_duplicate_events_on_parameter_update() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    let events_before = e.events().all().len();
+    client.set_protocol_fee_bps(&admin, &100);
+    let events_after = e.events().all().len();
+
+    // Exactly one event emitted per setter call
+    assert_eq!(events_after - events_before, 1, "expected exactly 1 event per setter");
+}

--- a/contracts/credence_treasury/src/treasury.rs
+++ b/contracts/credence_treasury/src/treasury.rs
@@ -272,9 +272,11 @@ impl CredenceTreasury {
         if threshold > count {
             panic_with_error!(&e, ContractError::ThresholdExceedsSigners);
         }
+        let old_threshold: u32 = e.storage().instance().get(&DataKey::Threshold).unwrap_or(0);
         e.storage().instance().set(&DataKey::Threshold, &threshold);
+        // Emit old and new values for auditability
         e.events()
-            .publish((Symbol::new(&e, "threshold_updated"),), threshold);
+            .publish((Symbol::new(&e, "threshold_updated"),), (old_threshold, threshold));
     }
 
     /// Propose a withdrawal. Only a signer can propose. Creates a proposal that can be approved and executed.


### PR DESCRIPTION
## feat(contracts): add events for critical config updates

Closes #138

### Summary

Several governance/admin parameter setters were emitting events without old values, reducing transparency and making off-chain diffing impossible. This PR fixes all affected setters to include both old and new values, and adds tests that assert event argument correctness.

### Changes

| File | What changed |
|---|---|
| `contracts/credence_bond/src/pausable.rs` | `set_pause_signer` and `set_pause_threshold` now emit `(old, new)` tuples instead of just the new value |
| `contracts/credence_treasury/src/treasury.rs` | `set_threshold` now reads and emits `old_threshold` alongside the new value |
| `contracts/credence_bond/src/test_parameters.rs` | Added Category 10 tests that assert actual event argument values, not just state changes |

### Before vs After

**`set_pause_signer`** (credence_bond)
```rust
// Before — no old value, can't diff
e.events().publish((Symbol::new(e, "pause_signer_set"), signer), enabled);

// After — old and new for auditability
e.events().publish((Symbol::new(e, "pause_signer_set"), signer), (old_enabled, enabled));
```

**`set_pause_threshold`** (credence_bond)
```rust
// Before
e.events().publish((Symbol::new(e, "pause_threshold_set"),), threshold);

// After
e.events().publish((Symbol::new(e, "pause_threshold_set"),), (old_threshold, threshold));
```

**`set_threshold`** (credence_treasury)
```rust
// Before
e.events().publish((Symbol::new(&e, "threshold_updated"),), threshold);

// After
let old_threshold: u32 = e.storage().instance().get(&DataKey::Threshold).unwrap_or(0);
e.events().publish((Symbol::new(&e, "threshold_updated"),), (old_threshold, threshold));
```

### Tests added (Category 10)

- `test_protocol_fee_event_args` — asserts `old_value` and `new_value` in `parameter_changed` event
- `test_attestation_fee_event_args` — same for attestation fee
- `test_withdrawal_cooldown_event_args` — same for withdrawal cooldown
- `test_pause_signer_event_includes_old_and_new` — asserts `(false, true)` on first enable
- `test_pause_threshold_event_includes_old_and_new` — asserts `(0, 1)` on first threshold set
- `test_no_duplicate_events_on_parameter_update` — asserts exactly 1 event per setter call

### Guidelines followed

- No existing events removed
- Indexed fields unchanged — only data payloads updated
- All setters remain governance-only
- Pre-existing compile errors in `lib.rs` (unrelated to this PR) were present on `main` before this branch was created