### PR TITLE
fix(contracts): enforce minimum timelock delay windows

### DIFF
--- a/contracts/timelock/src/test_timelock.rs
+++ b/contracts/timelock/src/test_timelock.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{Timelock, TimelockClient};
+use crate::{Timelock, TimelockClient, EXECUTION_GRACE_PERIOD};
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Address, Env, Symbol};
 
@@ -11,6 +11,16 @@ fn setup(e: &Env) -> (TimelockClient<'_>, Address, Address) {
     let governance = Address::generate(e);
     e.mock_all_auths();
     client.initialize(&admin, &governance, &86400);
+    (client, admin, governance)
+}
+
+fn setup_with_delay(e: &Env, min_delay: u64) -> (TimelockClient<'_>, Address, Address) {
+    let contract_id = e.register(Timelock, ());
+    let client = TimelockClient::new(e, &contract_id);
+    let admin = Address::generate(e);
+    let governance = Address::generate(e);
+    e.mock_all_auths();
+    client.initialize(&admin, &governance, &min_delay);
     (client, admin, governance)
 }
 
@@ -61,8 +71,43 @@ fn test_propose_change() {
     assert_eq!(change.new_value, 500);
     assert_eq!(change.proposed_at, 1000);
     assert_eq!(change.eta, 1000 + 86400);
+    assert_eq!(change.expires_at, 1000 + 86400 + EXECUTION_GRACE_PERIOD);
+    assert_eq!(change.min_delay_at_queue, 86400);
     assert!(!change.executed);
     assert!(!change.cancelled);
+}
+
+#[test]
+fn test_queue_change_with_exact_min_delay_eta() {
+    let e = Env::default();
+    let (client, admin, _gov) = setup_with_delay(&e, 10);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let key = Symbol::new(&e, "slash_rate");
+    let eta = 1010;
+    let id = client.queue_change(&admin, &key, &500, &eta);
+    let change = client.get_change(&id);
+
+    assert_eq!(change.eta, eta);
+    assert_eq!(change.expires_at, eta + EXECUTION_GRACE_PERIOD);
+    assert_eq!(change.min_delay_at_queue, 10);
+}
+
+#[test]
+#[should_panic(expected = "eta must satisfy min delay")]
+fn test_queue_change_eta_too_early_fails() {
+    let e = Env::default();
+    let (client, admin, _gov) = setup_with_delay(&e, 10);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let key = Symbol::new(&e, "slash_rate");
+    client.queue_change(&admin, &key, &500, &1009);
 }
 
 #[test]
@@ -98,6 +143,69 @@ fn test_execute_change_after_delay() {
     client.execute_change(&id);
     let change = client.get_change(&id);
     assert!(change.executed);
+}
+
+#[test]
+fn test_execute_change_at_eta_boundary() {
+    let e = Env::default();
+    let (client, admin, _gov) = setup_with_delay(&e, 10);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let key = Symbol::new(&e, "fee_bps");
+    let id = client.propose_change(&admin, &key, &250);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+
+    client.execute_change(&id);
+    let change = client.get_change(&id);
+    assert!(change.executed);
+}
+
+#[test]
+fn test_execute_change_at_expiration_boundary() {
+    let e = Env::default();
+    let (client, admin, _gov) = setup_with_delay(&e, 10);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let key = Symbol::new(&e, "fee_bps");
+    let id = client.propose_change(&admin, &key, &250);
+    let change = client.get_change(&id);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = change.expires_at;
+    });
+
+    client.execute_change(&id);
+    assert!(client.get_change(&id).executed);
+}
+
+#[test]
+#[should_panic(expected = "execution window expired")]
+fn test_execute_change_after_expiration_fails() {
+    let e = Env::default();
+    let (client, admin, _gov) = setup_with_delay(&e, 10);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+
+    let key = Symbol::new(&e, "fee_bps");
+    let id = client.propose_change(&admin, &key, &250);
+    let change = client.get_change(&id);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = change.expires_at + 1;
+    });
+
+    client.execute_change(&id);
 }
 
 #[test]

--- a/contracts/timelock/src/timelock.rs
+++ b/contracts/timelock/src/timelock.rs
@@ -6,6 +6,9 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
 
+/// Execution grace period in seconds after ETA.
+pub const EXECUTION_GRACE_PERIOD: u64 = 86_400;
+
 /// A pending parameter change. Created when admin proposes a new value for a
 /// protocol parameter. The change can only be executed after the ETA (estimated
 /// time of arrival) has passed.
@@ -20,6 +23,10 @@ pub struct ParameterChange {
     pub proposed_at: u64,
     /// Earliest timestamp at which the change can be executed.
     pub eta: u64,
+    /// Latest timestamp at which the change can be executed.
+    pub expires_at: u64,
+    /// Minimum delay enforced when the change was queued.
+    pub min_delay_at_queue: u64,
     /// True once the change has been executed.
     pub executed: bool,
     /// True if the change was cancelled by governance.
@@ -82,6 +89,40 @@ impl Timelock {
         parameter_key: Symbol,
         new_value: i128,
     ) -> u64 {
+        let min_delay: u64 = e
+            .storage()
+            .instance()
+            .get(&DataKey::MinDelay)
+            .unwrap_or_else(|| panic!("not initialized"));
+
+        if min_delay == 0 {
+            panic!("min_delay must be greater than zero");
+        }
+
+        let eta = e
+            .ledger()
+            .timestamp()
+            .checked_add(min_delay)
+            .expect("eta overflow");
+
+        Self::queue_change(e, proposer, parameter_key, new_value, eta)
+    }
+
+    /// Queue a parameter change with an explicit ETA. Only the admin can queue.
+    ///
+    /// @param e             The contract environment
+    /// @param proposer      Must be the admin
+    /// @param parameter_key Identifier for the parameter to change
+    /// @param new_value     The proposed new value
+    /// @param eta           Earliest timestamp for execution; must satisfy min delay
+    /// @return change_id    Unique ID for this pending change
+    pub fn queue_change(
+        e: Env,
+        proposer: Address,
+        parameter_key: Symbol,
+        new_value: i128,
+        eta: u64,
+    ) -> u64 {
         proposer.require_auth();
         let admin: Address = e
             .storage()
@@ -98,8 +139,19 @@ impl Timelock {
             .get(&DataKey::MinDelay)
             .unwrap_or_else(|| panic!("not initialized"));
 
+        if min_delay == 0 {
+            panic!("min_delay must be greater than zero");
+        }
+
         let now = e.ledger().timestamp();
-        let eta = now.checked_add(min_delay).expect("eta overflow");
+        let earliest_eta = now.checked_add(min_delay).expect("eta overflow");
+        if eta < earliest_eta {
+            panic!("eta must satisfy min delay");
+        }
+
+        let expires_at = eta
+            .checked_add(EXECUTION_GRACE_PERIOD)
+            .expect("execution window overflow");
 
         let id: u64 = e
             .storage()
@@ -116,6 +168,8 @@ impl Timelock {
             new_value,
             proposed_at: now,
             eta,
+            expires_at,
+            min_delay_at_queue: min_delay,
             executed: false,
             cancelled: false,
         };
@@ -160,6 +214,21 @@ impl Timelock {
         let now = e.ledger().timestamp();
         if now < change.eta {
             panic!("timelock delay has not elapsed");
+        }
+        if now > change.expires_at {
+            panic!("execution window expired");
+        }
+
+        if change.min_delay_at_queue == 0 {
+            panic!("min_delay must be greater than zero");
+        }
+
+        let earliest_eta = change
+            .proposed_at
+            .checked_add(change.min_delay_at_queue)
+            .expect("eta overflow");
+        if change.eta < earliest_eta {
+            panic!("eta must satisfy min delay");
         }
 
         change.executed = true;


### PR DESCRIPTION
Enforces strict timelock delay windows for queued operations.
Adds queue-time ETA validation against min delay, execute-time boundary checks (early/valid/expired), and tests for exact timestamp edges while preserving existing cancel behavior and event compatibility.

Closes #133 