### PR TITLE
chore(contracts): add per-crate coverage workflow (llvm-cov) (#287)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,63 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main, master, develop, 'feature/**']
+  pull_request:
+    branches: [main, master, develop]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Minimum line-coverage threshold (%) enforced per crate.
+  COVERAGE_THRESHOLD: 95
+
+jobs:
+  coverage:
+    name: Per-crate coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable + llvm-tools)
+        run: |
+          rustup toolchain install stable --profile minimal \
+            --component llvm-tools-preview
+          rustup default stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-coverage-
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Coverage — credence_bond
+        run: |
+          cargo llvm-cov --package credence_bond \
+            --fail-under-lines ${{ env.COVERAGE_THRESHOLD }} \
+            --lcov --output-path lcov-credence_bond.info
+
+      - name: Coverage — credence_delegation
+        run: |
+          cargo llvm-cov --package credence_delegation \
+            --fail-under-lines ${{ env.COVERAGE_THRESHOLD }} \
+            --lcov --output-path lcov-credence_delegation.info
+
+      - name: Coverage — timelock
+        run: |
+          cargo llvm-cov --package timelock \
+            --fail-under-lines ${{ env.COVERAGE_THRESHOLD }} \
+            --lcov --output-path lcov-timelock.info
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-reports
+          path: lcov-*.info

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cargo test -p credence_bond
 cargo test -p credence_delegation
 ```
 
+See [docs/testing.md](docs/testing.md) for coverage instructions (95% target, `cargo-llvm-cov`).
+
 ## Project layout
 
 - `contracts/credence_bond/` — Identity bond contract

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,46 @@
+# Testing & Coverage
+
+## Running tests
+
+```bash
+# All crates
+cargo test
+
+# Single crate
+cargo test -p credence_bond
+cargo test -p credence_delegation
+cargo test -p timelock
+```
+
+## Coverage (cargo-llvm-cov)
+
+The project targets **95% line coverage** per crate, enforced in CI via
+[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov).
+
+### One-time setup
+
+```bash
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov --locked
+```
+
+### Run locally
+
+```bash
+# HTML report (opens in browser)
+cargo llvm-cov --package credence_bond --open
+
+# Enforce threshold (same check as CI)
+cargo llvm-cov --package credence_bond --fail-under-lines 95
+cargo llvm-cov --package credence_delegation --fail-under-lines 95
+cargo llvm-cov --package timelock --fail-under-lines 95
+
+# LCOV output (for editor integration)
+cargo llvm-cov --package credence_bond --lcov --output-path lcov.info
+```
+
+### CI workflow
+
+`.github/workflows/coverage.yml` runs on every push/PR and fails the build
+if any of the three primary crates falls below 95% line coverage. LCOV
+reports are uploaded as a build artifact (`lcov-reports`).


### PR DESCRIPTION
## Summary

Closes #287.

Adds a repeatable coverage workflow targeting **95% line coverage** per crate, easy to run locally and enforced in CI.

## Changes

| File | What |
|---|---|
| `.github/workflows/coverage.yml` | New workflow: installs `cargo-llvm-cov`, runs per-crate coverage for `credence_bond`, `credence_delegation`, `timelock`; fails below 95%; uploads LCOV artifacts |
| `docs/testing.md` | Setup + local run instructions |
| `README.md` | Link to `docs/testing.md` |

## Running locally

```bash
rustup component add llvm-tools-preview
cargo install cargo-llvm-cov --locked

cargo llvm-cov --package credence_bond --fail-under-lines 95
cargo llvm-cov --package credence_delegation --fail-under-lines 95
cargo llvm-cov --package timelock --fail-under-lines 95
```