### PR TITLE
feat: governance-controlled borrow freeze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,10 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "admin"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk 21.7.7",
+ "soroban-sdk 22.0.10",
 ]
 
 [[package]]
@@ -78,7 +63,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -95,7 +80,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest",
- "itertools 0.10.5",
+ "itertools",
  "num-bigint",
  "num-traits",
  "paste",
@@ -179,31 +164,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
@@ -338,6 +302,7 @@ dependencies = [
 name = "credence_bond"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "credence_math",
  "soroban-sdk 22.0.10",
 ]
@@ -364,6 +329,7 @@ version = "0.1.0"
 name = "credence_multisig"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 22.0.10",
 ]
 
@@ -593,6 +559,7 @@ dependencies = [
 name = "dispute_resolution"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 23.5.3",
 ]
 
@@ -729,6 +696,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 name = "fixed_duration_bond"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "credence_math",
  "soroban-sdk 22.0.10",
 ]
@@ -762,12 +730,6 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "group"
@@ -919,15 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,15 +953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,15 +995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1207,12 +1142,6 @@ dependencies = [
  "hmac",
  "subtle",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -1403,23 +1332,11 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-builtin-sdk-macros"
 version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1431,29 +1348,10 @@ version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9336adeabcd6f636a4e0889c8baf494658ef5a3c4e7e227569acd2ce9091e85"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
-dependencies = [
- "arbitrary",
- "crate-git-revision",
- "ethnum",
- "num-derive",
- "num-traits",
- "serde",
- "soroban-env-macros 21.2.1",
- "soroban-wasmi",
- "static_assertions",
- "stellar-xdr 21.2.0",
- "wasmparser",
 ]
 
 [[package]]
@@ -1496,16 +1394,6 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
-dependencies = [
- "soroban-env-common 21.2.1",
- "static_assertions",
-]
-
-[[package]]
-name = "soroban-env-guest"
 version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
@@ -1522,39 +1410,6 @@ checksum = "ccd1e40963517b10963a8e404348d3fe6caf9c278ac47a6effd48771297374d6"
 dependencies = [
  "soroban-env-common 23.0.1",
  "static_assertions",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
-dependencies = [
- "backtrace",
- "curve25519-dalek",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "generic-array",
- "getrandom",
- "hex-literal",
- "hmac",
- "k256",
- "num-derive",
- "num-integer",
- "num-traits",
- "p256",
- "rand",
- "rand_chacha",
- "sec1",
- "sha2",
- "sha3",
- "soroban-builtin-sdk-macros 21.2.1",
- "soroban-env-common 21.2.1",
- "soroban-wasmi",
- "static_assertions",
- "stellar-strkey 0.0.8",
- "wasmparser",
 ]
 
 [[package]]
@@ -1631,26 +1486,11 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "stellar-xdr 21.2.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-env-macros"
 version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "serde",
@@ -1665,27 +1505,13 @@ version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0e6a1c5844257ce96f5f54ef976035d5bd0ee6edefaf9f5e0bcb8ea4b34228c"
 dependencies = [
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "stellar-xdr 23.0.0",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-ledger-snapshot"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6edf92749fd8399b417192d301c11f710b9cdce15789a3d157785ea971576fa"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "soroban-env-common 21.2.1",
- "soroban-env-host 21.2.1",
- "thiserror",
 ]
 
 [[package]]
@@ -1714,28 +1540,6 @@ dependencies = [
  "soroban-env-common 23.0.1",
  "soroban-env-host 23.0.1",
  "thiserror",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcdf04484af7cc731a7a48ad1d9f5f940370edeea84734434ceaf398a6b862e"
-dependencies = [
- "arbitrary",
- "bytes-lit",
- "ctor 0.2.9",
- "derive_arbitrary",
- "ed25519-dalek",
- "rand",
- "rustc_version",
- "serde",
- "serde_json",
- "soroban-env-guest 21.2.1",
- "soroban-env-host 21.2.1",
- "soroban-ledger-snapshot 21.7.7",
- "soroban-sdk-macros 21.7.7",
- "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -1786,33 +1590,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0974e413731aeff2443f2305b344578b3f1ffd18335a7ba0f0b5d2eb4e94c9ce"
-dependencies = [
- "crate-git-revision",
- "darling 0.20.11",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "sha2",
- "soroban-env-common 21.2.1",
- "soroban-spec 21.7.7",
- "soroban-spec-rust 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-sdk-macros"
 version = "22.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965b977c52d16dd8dfd9074702583e5a5778f230cda0fa78b2ea743e9149ac8d"
 dependencies = [
  "crate-git-revision",
  "darling 0.20.11",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1832,7 +1616,7 @@ checksum = "caa7114e2f031b6fbd30376e844f3c55f6daf56f6f9d33ce309f846ffced316d"
 dependencies = [
  "darling 0.20.11",
  "heck",
- "itertools 0.10.5",
+ "itertools",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -1842,18 +1626,6 @@ dependencies = [
  "soroban-spec-rust 23.5.3",
  "stellar-xdr 23.0.0",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "soroban-spec"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
-dependencies = [
- "base64 0.13.1",
- "stellar-xdr 21.2.0",
- "thiserror",
- "wasmparser",
 ]
 
 [[package]]
@@ -1878,22 +1650,6 @@ dependencies = [
  "stellar-xdr 23.0.0",
  "thiserror",
  "wasmparser",
-]
-
-[[package]]
-name = "soroban-spec-rust"
-version = "21.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dafbde981b141b191c6c036abc86097070ddd6eaaa33b273701449501e43d3"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "sha2",
- "soroban-spec 21.7.7",
- "stellar-xdr 21.2.0",
- "syn 2.0.117",
- "thiserror",
 ]
 
 [[package]]
@@ -1971,17 +1727,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
-dependencies = [
- "base32",
- "crate-git-revision",
- "thiserror",
-]
-
-[[package]]
-name = "stellar-strkey"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
@@ -2010,22 +1755,6 @@ dependencies = [
  "crate-git-revision",
  "data-encoding",
  "heapless",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "21.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2675a71212ed39a806e415b0dbf4702879ff288ec7f5ee996dda42a135512b50"
-dependencies = [
- "arbitrary",
- "base64 0.13.1",
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "serde",
- "serde_with",
- "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -2152,6 +1881,7 @@ dependencies = [
 name = "timelock"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 22.0.10",
 ]
 

--- a/contracts/credence_bond/src/lib.rs
+++ b/contracts/credence_bond/src/lib.rs
@@ -136,6 +136,8 @@ pub enum DataKey {
     SupplyCap,
     TotalSupply,
     LastCollateralIncreaseLedger,
+    // Borrow freeze
+    BorrowFrozen,
 }
 
 #[contract]
@@ -490,6 +492,7 @@ impl CredenceBond {
 
     pub fn create_bond(e: Env, identity: Address, amount: i128, duration: u64) -> IdentityBond {
         pausable::require_not_paused(&e);
+        parameters::require_not_borrow_frozen(&e);
         validation::validate_bond_amount(amount);
         validation::validate_bond_duration(duration);
         leverage::validate_leverage(amount, parameters::get_max_leverage(&e));
@@ -516,6 +519,7 @@ impl CredenceBond {
         validation::validate_bond_duration(duration);
 
         pausable::require_not_paused(&e);
+        parameters::require_not_borrow_frozen(&e);
         identity.require_auth();
         token_integration::transfer_into_contract(&e, &identity, amount);
         let bond_start = e.ledger().timestamp();
@@ -1303,6 +1307,7 @@ impl CredenceBond {
 
     pub fn top_up(e: Env, amount: i128) -> IdentityBond {
         pausable::require_not_paused(&e);
+        parameters::require_not_borrow_frozen(&e);
         if amount <= 0 {
             panic!("amount must be positive");
         }
@@ -1470,6 +1475,18 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         admin.require_auth();
         parameters::set_max_leverage(&e, &admin, value)
+    }
+
+    /// Returns whether new bond creation and top-ups are currently frozen.
+    pub fn is_borrow_frozen(e: Env) -> bool {
+        parameters::is_borrow_frozen(&e)
+    }
+
+    /// Freeze or unfreeze new bond creation and top-ups. Governance (admin) only.
+    /// Repayments and withdrawals are unaffected.
+    pub fn set_borrow_frozen(e: Env, admin: Address, frozen: bool) {
+        pausable::require_not_paused(&e);
+        parameters::set_borrow_frozen(&e, &admin, frozen)
     }
 
     pub fn withdraw_bond_full(e: Env, identity: Address) -> i128 {
@@ -2030,6 +2047,8 @@ mod test_validation;
 mod test_verifier;
 #[cfg(test)]
 mod test_weighted_attestation;
+#[cfg(test)]
+mod test_borrow_freeze;
 #[cfg(test)]
 mod test_withdraw_bond;
 #[cfg(test)]

--- a/contracts/credence_bond/src/parameters.rs
+++ b/contracts/credence_bond/src/parameters.rs
@@ -540,6 +540,46 @@ pub fn set_max_leverage(e: &Env, admin: &Address, value: u32) {
 }
 
 // ============================================================================
+// Borrow Freeze (Governance-Controlled)
+// ============================================================================
+
+/// Returns `true` when new borrows/increases are frozen.
+#[must_use]
+pub fn is_borrow_frozen(e: &Env) -> bool {
+    e.storage()
+        .instance()
+        .get(&crate::DataKey::BorrowFrozen)
+        .unwrap_or(false)
+}
+
+/// Panics with `BorrowFrozen` if borrows are currently frozen.
+pub fn require_not_borrow_frozen(e: &Env) {
+    if is_borrow_frozen(e) {
+        panic!("borrow frozen");
+    }
+}
+
+/// Freeze or unfreeze new bond creation and top-ups. Governance-only.
+///
+/// Repayments and withdrawals are unaffected.
+///
+/// # Events
+/// Emits `borrow_freeze_set(frozen, admin, timestamp)`.
+pub fn set_borrow_frozen(e: &Env, admin: &Address, frozen: bool) {
+    validate_admin(e, admin);
+    admin.require_auth();
+    let old = is_borrow_frozen(e);
+    e.storage()
+        .instance()
+        .set(&crate::DataKey::BorrowFrozen, &frozen);
+    let timestamp = e.ledger().timestamp();
+    e.events().publish(
+        (Symbol::new(e, "borrow_freeze_set"),),
+        (old, frozen, admin.clone(), timestamp),
+    );
+}
+
+// ============================================================================
 // Internal Helpers
 // ============================================================================
 

--- a/contracts/credence_bond/src/test_borrow_freeze.rs
+++ b/contracts/credence_bond/src/test_borrow_freeze.rs
@@ -1,0 +1,147 @@
+#![cfg(test)]
+
+use crate::test_helpers;
+use crate::{CredenceBond, CredenceBondClient};
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{Address, Env};
+
+fn setup_no_token(e: &Env) -> (CredenceBondClient<'_>, Address) {
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceBond, ());
+    let client = CredenceBondClient::new(e, &contract_id);
+    let admin = Address::generate(e);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ── default state ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_borrow_freeze_default_false() {
+    let e = Env::default();
+    let (client, _admin) = setup_no_token(&e);
+    assert!(!client.is_borrow_frozen());
+}
+
+// ── governance set / unset ────────────────────────────────────────────────────
+
+#[test]
+fn test_set_borrow_frozen_true_and_false() {
+    let e = Env::default();
+    let (client, admin) = setup_no_token(&e);
+
+    client.set_borrow_frozen(&admin, &true);
+    assert!(client.is_borrow_frozen());
+
+    client.set_borrow_frozen(&admin, &false);
+    assert!(!client.is_borrow_frozen());
+}
+
+#[test]
+fn test_set_borrow_frozen_non_admin_rejected() {
+    let e = Env::default();
+    let (client, _admin) = setup_no_token(&e);
+    let rando = Address::generate(&e);
+
+    assert!(client.try_set_borrow_frozen(&rando, &true).is_err());
+    assert!(!client.is_borrow_frozen());
+}
+
+// ── create_bond blocked ───────────────────────────────────────────────────────
+
+#[test]
+fn test_create_bond_blocked_when_frozen() {
+    let e = Env::default();
+    let (client, admin, identity, _token, _bond_id) = test_helpers::setup_with_token(&e);
+
+    client.set_borrow_frozen(&admin, &true);
+
+    assert!(client
+        .try_create_bond(&identity, &1_000_i128, &86_400_u64)
+        .is_err());
+}
+
+#[test]
+fn test_create_bond_with_rolling_blocked_when_frozen() {
+    let e = Env::default();
+    let (client, admin, identity, _token, _bond_id) = test_helpers::setup_with_token(&e);
+
+    client.set_borrow_frozen(&admin, &true);
+
+    assert!(client
+        .try_create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64)
+        .is_err());
+}
+
+// ── top_up blocked ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_top_up_blocked_when_frozen() {
+    let e = Env::default();
+    let (client, admin, identity, _token, _bond_id) = test_helpers::setup_with_token(&e);
+
+    // Create bond first (freeze not yet active)
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+
+    client.set_borrow_frozen(&admin, &true);
+
+    assert!(client.try_top_up(&1_000_i128).is_err());
+}
+
+// ── withdrawals still allowed ─────────────────────────────────────────────────
+
+#[test]
+fn test_withdraw_allowed_when_frozen() {
+    let e = Env::default();
+    let (client, admin, identity, _token, _bond_id) = test_helpers::setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+
+    client.set_borrow_frozen(&admin, &true);
+
+    // withdraw_bond_full should succeed even while frozen
+    let withdrawn = client.withdraw_bond_full(&identity);
+    assert!(withdrawn > 0);
+}
+
+// ── unfreeze restores create_bond ─────────────────────────────────────────────
+
+#[test]
+fn test_create_bond_allowed_after_unfreeze() {
+    let e = Env::default();
+    let (client, admin, identity, _token, _bond_id) = test_helpers::setup_with_token(&e);
+
+    client.set_borrow_frozen(&admin, &true);
+    assert!(client
+        .try_create_bond(&identity, &1_000_i128, &86_400_u64)
+        .is_err());
+
+    client.set_borrow_frozen(&admin, &false);
+    let bond = client.create_bond(&identity, &1_000_i128, &86_400_u64);
+    assert!(bond.active);
+}
+
+// ── event emitted ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_borrow_frozen_emits_event() {
+    let e = Env::default();
+    let (client, admin) = setup_no_token(&e);
+
+    client.set_borrow_frozen(&admin, &true);
+
+    // Verify the event was published (at least one event exists after the call)
+    let events = e.events().all();
+    assert!(!events.is_empty());
+}
+
+// ── paused contract blocks set_borrow_frozen ──────────────────────────────────
+
+#[test]
+fn test_set_borrow_frozen_blocked_when_paused() {
+    let e = Env::default();
+    let (client, admin) = setup_no_token(&e);
+
+    client.pause(&admin);
+    assert!(client.try_set_borrow_frozen(&admin, &true).is_err());
+}

--- a/docs/emergency.md
+++ b/docs/emergency.md
@@ -195,6 +195,65 @@ Planned improvements to the pause mechanism:
 - Emergency override keys
 - Cross-contract coordinated pausing
 - Integration with external monitoring systems
+
+---
+
+# Governance-Controlled Borrow Freeze
+
+## Overview
+
+The borrow freeze is a targeted governance control that blocks new bond creation and top-ups while leaving all safe-exit paths (withdrawals, repayments, emergency withdrawals) fully available. It is lighter-weight than a full contract pause and is intended for risk-management scenarios such as market stress, oracle issues, or pending governance votes.
+
+## API
+
+### `is_borrow_frozen() -> bool`
+Returns the current borrow-freeze state. Safe to call at any time.
+
+### `set_borrow_frozen(admin: Address, frozen: bool)`
+Freeze (`true`) or unfreeze (`false`) new borrows/increases. Only the contract admin (governance) may call this. Blocked when the contract is fully paused.
+
+## Affected Operations
+
+| Operation | Frozen? |
+|---|---|
+| `create_bond` | ✅ blocked |
+| `create_bond_with_rolling` | ✅ blocked |
+| `top_up` | ✅ blocked |
+| `withdraw_bond_full` | ❌ allowed |
+| `emergency_withdraw` | ❌ allowed |
+| `slash_bond` | ❌ allowed |
+| All read functions | ❌ allowed |
+
+## Events
+
+`set_borrow_frozen` emits:
+
+```
+topic:  ("borrow_freeze_set",)
+data:   (old_frozen: bool, new_frozen: bool, admin: Address, timestamp: u64)
+```
+
+## Security Notes
+
+- Only the stored admin address can toggle the freeze; non-admin callers are rejected with `"not admin"`.
+- `set_borrow_frozen` itself is blocked when the contract is fully paused (`ContractPaused`).
+- The freeze state defaults to `false` (unfrozen) and does not require explicit initialization.
+- Freeze state is stored under `DataKey::BorrowFrozen` in instance storage.
+
+## Test Coverage
+
+`test_borrow_freeze.rs` covers:
+
+- Default state is unfrozen.
+- Admin can freeze and unfreeze.
+- Non-admin is rejected.
+- `create_bond` blocked when frozen.
+- `create_bond_with_rolling` blocked when frozen.
+- `top_up` blocked when frozen.
+- `withdraw_bond_full` succeeds when frozen.
+- `create_bond` succeeds after unfreeze.
+- Event emitted on state change.
+- `set_borrow_frozen` blocked when contract is paused.
 # Emergency Withdrawal System
 
 Emergency withdrawal is a crisis-only escape hatch that lets governance execute withdrawals with elevated approval while preserving a complete on-chain audit trail.


### PR DESCRIPTION
- Add BorrowFrozen DataKey to instance storage
- Add is_borrow_frozen / require_not_borrow_frozen / set_borrow_frozen in parameters.rs
- Guard create_bond, create_bond_with_rolling, and top_up with require_not_borrow_frozen
- Expose is_borrow_frozen and set_borrow_frozen as public contract methods
- Add test_borrow_freeze.rs covering default state, admin toggle, non-admin rejection, affected/unaffected operations, unfreeze recovery, event emission, and pause interaction
- Document feature in docs/emergency.md

closes #268 