### PR TITLE
refactor(contracts): migrate core reverts to custom errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "admin"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 22.0.10",
 ]
 
@@ -295,6 +296,7 @@ dependencies = [
 name = "credence_arbitration"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 22.0.10",
 ]
 
@@ -311,6 +313,7 @@ dependencies = [
 name = "credence_delegation"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk 22.0.10",
 ]
 
@@ -1824,6 +1827,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "templates"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 22.0.10",
 ]
 
 [[package]]

--- a/contracts/admin/Cargo.toml
+++ b/contracts/admin/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = "22.0"
+credence_errors = { path = "../credence_errors" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0", features = ["testutils"] }

--- a/contracts/admin/src/lib.rs
+++ b/contracts/admin/src/lib.rs
@@ -6,6 +6,8 @@ pub mod pausable;
 mod test_ownership_transfer;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use credence_errors::ContractError;
+use soroban_sdk::panic_with_error;
 
 /// Admin role hierarchy levels
 #[contracttype]
@@ -86,15 +88,15 @@ impl AdminContract {
     /// Emits `admin_initialized` with the super admin address
     pub fn initialize(e: Env, super_admin: Address, min_admins: u32, max_admins: u32) {
         if e.storage().instance().has(&DataKey::Initialized) {
-            panic!("already initialized");
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
         }
 
         if min_admins == 0 {
-            panic!("min_admins cannot be zero");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         if min_admins > max_admins {
-            panic!("min_admins cannot be greater than max_admins");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         super_admin.require_auth();
@@ -182,19 +184,19 @@ impl AdminContract {
 
         // Verify caller authorization
         Self::require_role_at_least(&e, &caller, Self::get_required_role_to_assign(role))
-            .unwrap_or_else(|_| panic!("insufficient privileges"));
+            .unwrap_or_else(|_| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Check if new admin already exists
         if e.storage()
             .instance()
             .has(&DataKey::AdminInfo(new_admin.clone()))
         {
-            panic!("address is already an admin");
+            panic_with_error!(&e, ContractError::AlreadyActive);
         }
 
         // Prevent self-assignment of equal or higher role
         if caller == new_admin && Self::get_role(e.clone(), caller.clone()) >= role {
-            panic!("cannot assign equal or higher role to self");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         // Check admin limit
@@ -205,7 +207,7 @@ impl AdminContract {
             .get(&DataKey::MaxAdmins)
             .unwrap_or(100);
         if current_count >= max_admins {
-            panic!("maximum admin limit reached");
+            panic_with_error!(&e, ContractError::ThresholdExceedsSigners);
         }
 
         // Create admin info
@@ -271,12 +273,12 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(admin_to_remove.clone()))
-            .unwrap_or_else(|| panic!("admin not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Verify caller authorization
         let caller_role = Self::get_role(e.clone(), caller.clone());
         if caller_role <= admin_info.role {
-            panic!("insufficient privileges to remove admin");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         // Check minimum admin requirements
@@ -290,7 +292,7 @@ impl AdminContract {
 
         // Special protection for super admins
         if admin_info.role == AdminRole::SuperAdmin && role_admins.len() <= min_admins {
-            panic!("cannot remove last super admin");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         // Remove from admin info storage
@@ -306,7 +308,7 @@ impl AdminContract {
             .unwrap_or(Vec::new(&e));
         let admin_index = admin_list.iter().position(|x| x == admin_to_remove);
         if let Some(index) = admin_index {
-            admin_list.remove(index.try_into().unwrap());
+            admin_list.remove(index.try_into().unwrap_or_else(|_| panic_with_error!(&e, ContractError::Overflow)));
             e.storage().instance().set(&DataKey::AdminList, &admin_list);
         }
 
@@ -318,7 +320,7 @@ impl AdminContract {
             .unwrap_or(Vec::new(&e));
         let role_index = role_admins.iter().position(|x| x == admin_to_remove);
         if let Some(index) = role_index {
-            role_admins.remove(index.try_into().unwrap());
+            role_admins.remove(index.try_into().unwrap_or_else(|_| panic_with_error!(&e, ContractError::Overflow)));
             e.storage()
                 .instance()
                 .set(&DataKey::RoleAdmins(admin_info.role), &role_admins);
@@ -359,15 +361,15 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(admin_address.clone()))
-            .unwrap_or_else(|| panic!("admin not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Verify caller authorization
         Self::require_role_at_least(&e, &caller, Self::get_required_role_to_assign(new_role))
-            .unwrap_or_else(|_| panic!("insufficient privileges"));
+            .unwrap_or_else(|_| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Prevent self-assignment of equal or higher role
         if caller == admin_address && Self::get_role(e.clone(), caller.clone()) >= new_role {
-            panic!("cannot assign equal or higher role to self");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         let old_role = admin_info.role;
@@ -380,7 +382,7 @@ impl AdminContract {
             .unwrap_or(Vec::new(&e));
         let old_index = old_role_admins.iter().position(|x| x == admin_address);
         if let Some(index) = old_index {
-            old_role_admins.remove(index.try_into().unwrap());
+            old_role_admins.remove(index.try_into().unwrap_or_else(|_| panic_with_error!(&e, ContractError::Overflow)));
             e.storage()
                 .instance()
                 .set(&DataKey::RoleAdmins(old_role), &old_role_admins);
@@ -437,17 +439,17 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(admin_address.clone()))
-            .unwrap_or_else(|| panic!("admin not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Verify caller authorization
         let caller_role = Self::get_role(e.clone(), caller.clone());
         // Allow deactivation when caller has the same role as the target.
         if caller_role < admin_info.role {
-            panic!("insufficient privileges to deactivate admin");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         if !admin_info.active {
-            panic!("admin already deactivated");
+            panic_with_error!(&e, ContractError::AlreadyDeactivated);
         }
 
         admin_info.active = false;
@@ -481,17 +483,17 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(admin_address.clone()))
-            .unwrap_or_else(|| panic!("admin not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
 
         // Verify caller authorization
         let caller_role = Self::get_role(e.clone(), caller.clone());
         // Allow reactivation when caller has the same role as the target.
         if caller_role < admin_info.role {
-            panic!("insufficient privileges to reactivate admin");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         if admin_info.active {
-            panic!("admin already active");
+            panic_with_error!(&e, ContractError::AlreadyActive);
         }
 
         admin_info.active = true;
@@ -531,16 +533,16 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::Owner)
-            .unwrap_or_else(|| panic!("owner not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
 
         // Verify caller is the current owner
         if caller != current_owner {
-            panic!("only current owner can transfer ownership");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         // Verify new owner is different from current owner
         if new_owner == current_owner {
-            panic!("new owner must be different from current owner");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         // Verify new owner is a SuperAdmin
@@ -548,14 +550,14 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(new_owner.clone()))
-            .unwrap_or_else(|| panic!("new owner must be an existing admin"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
 
         if new_owner_info.role != AdminRole::SuperAdmin {
-            panic!("new owner must have SuperAdmin role");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         if !new_owner_info.active {
-            panic!("new owner must be active");
+            panic_with_error!(&e, ContractError::AlreadyDeactivated);
         }
 
         // Store pending owner
@@ -593,11 +595,11 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::PendingOwner)
-            .unwrap_or_else(|| panic!("no pending owner"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
 
         // Verify caller is the pending owner
         if caller != pending_owner {
-            panic!("only pending owner can accept ownership");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         // Get current owner for event emission
@@ -605,7 +607,7 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::Owner)
-            .unwrap_or_else(|| panic!("owner not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
 
         // Transfer ownership
         e.storage()
@@ -632,7 +634,7 @@ impl AdminContract {
         e.storage()
             .instance()
             .get(&DataKey::Owner)
-            .unwrap_or_else(|| panic!("owner not found"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     /// Get the pending owner (if any) for the current ownership transfer.
@@ -657,7 +659,7 @@ impl AdminContract {
         e.storage()
             .instance()
             .get(&DataKey::AdminInfo(admin_address))
-            .unwrap_or_else(|| panic!("admin not found"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin))
     }
 
     /// Check if an address is an admin and return their role.
@@ -672,7 +674,7 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(address))
-            .unwrap_or_else(|| panic!("address is not an admin"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
         admin_info.role
     }
 
@@ -776,12 +778,12 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::MinAdmins)
-            .unwrap_or_else(|| panic!("contract not initialized - min_admins not set"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         let max_admins: u32 = e
             .storage()
             .instance()
             .get(&DataKey::MaxAdmins)
-            .unwrap_or_else(|| panic!("contract not initialized - max_admins not set"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         (min_admins, max_admins)
     }
 
@@ -793,7 +795,7 @@ impl AdminContract {
             .storage()
             .instance()
             .get(&DataKey::AdminInfo(address))
-            .unwrap_or_else(|| panic!("address is not an admin"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotAdmin));
         admin_info.role
     }
 

--- a/contracts/admin/src/pausable.rs
+++ b/contracts/admin/src/pausable.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{Address, Env, Symbol};
+use credence_errors::ContractError;
+use soroban_sdk::{panic_with_error, Address, Env, Symbol};
 
 use crate::DataKey;
 
@@ -15,7 +16,7 @@ fn require_admin_auth(e: &Env, admin: &Address) {
 
     let caller_role = AdminContract::get_role(e.clone(), admin.clone());
     if caller_role != AdminRole::SuperAdmin {
-        panic!("not super admin");
+        panic_with_error!(e, ContractError::NotAdmin);
     }
     admin.require_auth();
 }
@@ -29,7 +30,7 @@ pub fn is_paused(e: &Env) -> bool {
 
 pub fn require_not_paused(e: &Env) {
     if is_paused(e) {
-        panic!("contract is paused");
+        panic_with_error!(e, ContractError::ContractPaused);
     }
 }
 
@@ -95,7 +96,7 @@ pub fn set_pause_threshold(e: &Env, admin: &Address, threshold: u32) {
         .get(&DataKey::PauseSignerCount)
         .unwrap_or(0);
     if threshold > count {
-        panic!("threshold cannot exceed signer count");
+        panic_with_error!(e, ContractError::ThresholdExceedsSigners);
     }
     e.storage()
         .instance()
@@ -112,7 +113,7 @@ fn require_pause_signer(e: &Env, signer: &Address) {
         .get(&DataKey::PauseSigner(signer.clone()))
         .unwrap_or(false);
     if !ok {
-        panic!("not pause signer");
+        panic_with_error!(e, ContractError::NotSigner);
     }
 }
 
@@ -122,7 +123,9 @@ fn next_proposal_id(e: &Env) -> u64 {
         .instance()
         .get(&DataKey::PauseProposalCounter)
         .unwrap_or(0);
-    let next = id.checked_add(1).expect("pause proposal counter overflow");
+    let next = id
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseProposalCounter, &next);
@@ -140,7 +143,9 @@ fn record_approval(e: &Env, proposal_id: u64, signer: &Address) {
         .instance()
         .get(&DataKey::PauseApprovalCount(proposal_id))
         .unwrap_or(0);
-    let new_count = count.checked_add(1).expect("pause approval count overflow");
+    let new_count = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseApprovalCount(proposal_id), &new_count);
@@ -202,7 +207,7 @@ pub fn approve_pause_proposal(e: &Env, signer: &Address, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     record_approval(e, proposal_id, signer);
 
@@ -217,7 +222,7 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     let threshold: u32 = e
         .storage()
@@ -231,13 +236,13 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .unwrap_or(0);
 
     if approvals < threshold {
-        panic!("insufficient approvals to execute");
+        panic_with_error!(e, ContractError::InsufficientApprovals);
     }
 
     match action {
         1 => do_pause(e, Some(proposal_id)),
         2 => do_unpause(e, Some(proposal_id)),
-        _ => panic!("invalid pause action"),
+        _ => panic_with_error!(e, ContractError::InvalidPauseAction),
     }
 
     e.storage()

--- a/contracts/admin/src/test.rs
+++ b/contracts/admin/src/test.rs
@@ -75,7 +75,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "already initialized")]
+    #[should_panic(expected = "Error(Contract, #2)")]
     fn test_double_initialization() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -87,7 +87,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "min_admins cannot be zero")]
+    #[should_panic(expected = "Error(Contract, #107)")]
     fn test_initialize_rejects_min_admins_zero() {
         let env = Env::default();
         let contract = create_contract();
@@ -101,7 +101,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "min_admins cannot be greater than max_admins")]
+    #[should_panic(expected = "Error(Contract, #107)")]
     fn test_initialize_rejects_min_greater_than_max() {
         let env = Env::default();
         let contract = create_contract();
@@ -148,7 +148,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_add_admin_rejects_insufficient_privileges() {
         let env = Env::default();
         let (contract_address, _super_admin, admin, _operator) = setup_multiple_admins(&env);
@@ -166,7 +166,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "address is already an admin")]
+    #[should_panic(expected = "Error(Contract, #405)")]
     fn test_add_admin_rejects_duplicate_admin() {
         let env = Env::default();
         let (contract_address, super_admin, admin, _operator) = setup_multiple_admins(&env);
@@ -183,7 +183,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "maximum admin limit reached")]
+    #[should_panic(expected = "Error(Contract, #601)")]
     fn test_add_admin_respects_max_limit() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_with_limits(&env, 1, 2);
@@ -213,7 +213,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "address is already an admin")]
+    #[should_panic(expected = "Error(Contract, #405)")]
     fn test_add_admin_rejects_self_add_as_duplicate_admin() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -248,7 +248,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "admin not found")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_remove_admin_rejects_non_admin_target() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -261,7 +261,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges to remove admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_remove_admin_rejects_insufficient_privileges() {
         let env = Env::default();
         let (contract_address, _super_admin, admin, operator) = setup_multiple_admins(&env);
@@ -273,7 +273,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges to remove admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_remove_admin_rejects_removing_super_admin() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_with_limits(&env, 1, 100);
@@ -319,7 +319,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_update_admin_role_rejects_insufficient_privileges() {
         let env = Env::default();
         let (contract_address, _super_admin, admin, operator) = setup_multiple_admins(&env);
@@ -336,7 +336,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "admin not found")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_update_admin_role_rejects_non_admin_target() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -354,7 +354,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot assign equal or higher role to self")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_update_admin_role_prevents_self_assign_equal_or_higher() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -428,7 +428,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges to deactivate admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_deactivate_admin_rejects_insufficient_privileges() {
         let env = Env::default();
         let (contract_address, _super_admin, admin, operator) = setup_multiple_admins(&env);
@@ -440,7 +440,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "admin already deactivated")]
+    #[should_panic(expected = "Error(Contract, #404)")]
     fn test_deactivate_admin_rejects_double_deactivate() {
         let env = Env::default();
         let (contract_address, super_admin, admin, _) = setup_multiple_admins(&env);
@@ -457,7 +457,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient privileges to reactivate admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_reactivate_admin_rejects_insufficient_privileges() {
         let env = Env::default();
         let (contract_address, super_admin, admin, operator) = setup_multiple_admins(&env);
@@ -474,7 +474,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "admin already active")]
+    #[should_panic(expected = "Error(Contract, #405)")]
     fn test_reactivate_admin_rejects_when_already_active() {
         let env = Env::default();
         let (contract_address, super_admin, admin, _) = setup_multiple_admins(&env);
@@ -574,7 +574,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "admin not found")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_get_admin_info_panics_for_non_admin() {
         let env = Env::default();
         let (contract_address, _super_admin) = setup_contract(&env);
@@ -586,7 +586,7 @@ mod comprehensive_tests {
     }
 
     #[test]
-    #[should_panic(expected = "address is not an admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_get_admin_role_panics_for_non_admin() {
         let env = Env::default();
         let (contract_address, _super_admin) = setup_contract(&env);

--- a/contracts/admin/src/test_immutable_config.rs
+++ b/contracts/admin/src/test_immutable_config.rs
@@ -102,7 +102,7 @@ mod immutable_config_tests {
             
             assert!(result.is_err());
             let panic_msg = result.unwrap_err().downcast::<String>().unwrap();
-            assert!(panic_msg.contains("already initialized"));
+            assert!(panic_msg.contains("Error(Contract, #2)"));
         });
     }
 }

--- a/contracts/admin/src/test_ownership_transfer.rs
+++ b/contracts/admin/src/test_ownership_transfer.rs
@@ -161,7 +161,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "only current owner can transfer ownership")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_transfer_ownership_rejects_non_owner() {
         let env = Env::default();
         let (contract_address, super_admin_1, super_admin_2) = setup_multiple_super_admins(&env);
@@ -189,7 +189,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "only pending owner can accept ownership")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_accept_ownership_rejects_non_pending_owner() {
         let env = Env::default();
         let contract = create_contract();
@@ -240,7 +240,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "new owner must be different from current owner")]
+    #[should_panic(expected = "Error(Contract, #107)")]
     fn test_transfer_ownership_rejects_same_owner() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -256,7 +256,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "new owner must be an existing admin")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_transfer_ownership_rejects_non_admin() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);
@@ -269,7 +269,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "new owner must have SuperAdmin role")]
+    #[should_panic(expected = "Error(Contract, #100)")]
     fn test_transfer_ownership_rejects_non_super_admin() {
         let env = Env::default();
         let contract = create_contract();
@@ -303,7 +303,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "new owner must be active")]
+    #[should_panic(expected = "Error(Contract, #404)")]
     fn test_transfer_ownership_rejects_inactive_admin() {
         let env = Env::default();
         let (contract_address, super_admin_1, super_admin_2) = setup_multiple_super_admins(&env);
@@ -336,7 +336,7 @@ mod ownership_transfer_tests {
     }
 
     #[test]
-    #[should_panic(expected = "no pending owner")]
+    #[should_panic(expected = "Error(Contract, #1)")]
     fn test_accept_ownership_rejects_when_no_pending_owner() {
         let env = Env::default();
         let (contract_address, super_admin) = setup_contract(&env);

--- a/contracts/arbitration/Cargo.toml
+++ b/contracts/arbitration/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { version = "22.0", features = ["testutils"] }
+credence_errors = { path = "../credence_errors" }

--- a/contracts/arbitration/src/lib.rs
+++ b/contracts/arbitration/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, String, Symbol};
+use credence_errors::ContractError;
+use soroban_sdk::{
+    contract, contractimpl, contracttype, panic_with_error, Address, Env, Map, String, Symbol,
+};
 
 pub mod pausable;
 pub mod status;
@@ -121,11 +124,15 @@ impl CredenceArbitration {
 
         let counter_key = DataKey::DisputeCounter;
         let id: u64 = e.storage().instance().get(&counter_key).unwrap_or(0);
-        let next_id = id.checked_add(1).expect("dispute counter overflow");
+        let next_id = id
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         e.storage().instance().set(&counter_key, &next_id);
 
         let start = e.ledger().timestamp();
-        let end = start.checked_add(duration).expect("duration overflow");
+        let end = start
+            .checked_add(duration)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
 
         // Open → Voting is the initial transition on creation
         require_transition(DisputeStatus::Open, DisputeStatus::Voting)?;
@@ -250,7 +257,9 @@ impl CredenceArbitration {
         let current_tally = votes.get(outcome).unwrap_or(0);
         votes.set(
             outcome,
-            current_tally.checked_add(weight).expect("weight overflow"),
+            current_tally
+                .checked_add(weight)
+                .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow)),
         );
         e.storage().instance().set(&votes_key, &votes);
 

--- a/contracts/arbitration/src/pausable.rs
+++ b/contracts/arbitration/src/pausable.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{Address, Env, Symbol};
+use credence_errors::ContractError;
+use soroban_sdk::{panic_with_error, Address, Env, Symbol};
 
 use crate::DataKey;
 
@@ -14,9 +15,9 @@ fn require_admin_auth(e: &Env, admin: &Address) {
         .storage()
         .instance()
         .get(&DataKey::Admin)
-        .unwrap_or_else(|| panic!("not initialized"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
     if stored_admin != *admin {
-        panic!("not admin");
+        panic_with_error!(e, ContractError::NotAdmin);
     }
     admin.require_auth();
 }
@@ -30,7 +31,7 @@ pub fn is_paused(e: &Env) -> bool {
 
 pub fn require_not_paused(e: &Env) {
     if is_paused(e) {
-        panic!("contract is paused");
+        panic_with_error!(e, ContractError::ContractPaused);
     }
 }
 
@@ -94,7 +95,7 @@ pub fn set_pause_threshold(e: &Env, admin: &Address, threshold: u32) {
         .get(&DataKey::PauseSignerCount)
         .unwrap_or(0);
     if threshold > count {
-        panic!("threshold cannot exceed signer count");
+        panic_with_error!(e, ContractError::ThresholdExceedsSigners);
     }
     e.storage()
         .instance()
@@ -111,7 +112,7 @@ fn require_pause_signer(e: &Env, signer: &Address) {
         .get(&DataKey::PauseSigner(signer.clone()))
         .unwrap_or(false);
     if !ok {
-        panic!("not pause signer");
+        panic_with_error!(e, ContractError::NotSigner);
     }
 }
 
@@ -121,7 +122,9 @@ fn next_proposal_id(e: &Env) -> u64 {
         .instance()
         .get(&DataKey::PauseProposalCounter)
         .unwrap_or(0);
-    let next = id.checked_add(1).expect("pause proposal counter overflow");
+    let next = id
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseProposalCounter, &next);
@@ -139,7 +142,9 @@ fn record_approval(e: &Env, proposal_id: u64, signer: &Address) {
         .instance()
         .get(&DataKey::PauseApprovalCount(proposal_id))
         .unwrap_or(0);
-    let new_count = count.checked_add(1).expect("pause approval count overflow");
+    let new_count = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseApprovalCount(proposal_id), &new_count);
@@ -201,7 +206,7 @@ pub fn approve_pause_proposal(e: &Env, signer: &Address, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     record_approval(e, proposal_id, signer);
 
@@ -216,7 +221,7 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     let threshold: u32 = e
         .storage()
@@ -230,13 +235,13 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .unwrap_or(0);
 
     if approvals < threshold {
-        panic!("insufficient approvals to execute");
+        panic_with_error!(e, ContractError::InsufficientApprovals);
     }
 
     match action {
         1 => do_pause(e, Some(proposal_id)),
         2 => do_unpause(e, Some(proposal_id)),
-        _ => panic!("invalid pause action"),
+        _ => panic_with_error!(e, ContractError::InvalidPauseAction),
     }
 
     e.storage()

--- a/contracts/credence_delegation/Cargo.toml
+++ b/contracts/credence_delegation/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { version = "22.0", features = ["testutils"] }
+credence_errors = { path = "../credence_errors" }

--- a/contracts/credence_delegation/src/domain.rs
+++ b/contracts/credence_delegation/src/domain.rs
@@ -18,7 +18,8 @@
 //! signature produced for `domain = Delegate` will be structurally incompatible
 //! with a `revoke_delegation` call even if the nonce happens to match.
 
-use soroban_sdk::{contracttype, Address, Env};
+use credence_errors::ContractError;
+use soroban_sdk::{contracttype, panic_with_error, Address, Env};
 
 /// Labels each function domain that accepts a delegated (off-chain) signature.
 ///
@@ -71,15 +72,15 @@ pub fn verify_payload(
     caller_target: &Address,
 ) {
     if payload.domain != expected_domain {
-        panic!("domain mismatch: payload domain does not match target function");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
     if &payload.owner != caller_owner {
-        panic!("payload owner mismatch");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
     if &payload.target != caller_target {
-        panic!("payload target mismatch");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
     if payload.contract_id != e.current_contract_address() {
-        panic!("payload contract_id mismatch: cross-contract replay detected");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
 }

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::panic_with_error;
+use credence_errors::ContractError;
 
 pub mod domain;
 pub mod nonce;
@@ -72,7 +74,7 @@ impl CredenceDelegation {
     /// Initialize the contract with an admin address.
     pub fn initialize(e: Env, admin: Address) {
         if e.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
         }
         e.storage().instance().set(&DataKey::Admin, &admin);
         e.storage().instance().set(&DataKey::Paused, &false);
@@ -102,7 +104,7 @@ impl CredenceDelegation {
         owner.require_auth();
 
         if expires_at <= e.ledger().timestamp() {
-            panic!("expiry must be in the future");
+            panic_with_error!(&e, ContractError::ExpiryInPast);
         }
 
         Self::store_delegation(&e, owner, delegate, delegation_type, expires_at)
@@ -170,7 +172,7 @@ impl CredenceDelegation {
         nonce::consume_nonce(&e, &owner, payload.nonce);
 
         if expires_at <= e.ledger().timestamp() {
-            panic!("expiry must be in the future");
+            panic_with_error!(&e, ContractError::ExpiryInPast);
         }
 
         Self::store_delegation(&e, owner, delegate, delegation_type, expires_at)
@@ -241,7 +243,7 @@ impl CredenceDelegation {
         e.storage()
             .instance()
             .get(&key)
-            .unwrap_or_else(|| panic!("delegation not found"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::DelegationNotFound))
     }
 
     /// Check whether a delegate is currently valid (not revoked, not expired).
@@ -371,10 +373,10 @@ impl CredenceDelegation {
             .storage()
             .instance()
             .get(&key)
-            .unwrap_or_else(|| panic!("{} not found", kind));
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::DelegationNotFound));
 
         if d.revoked {
-            panic!("{} already revoked", kind);
+            panic_with_error!(e, ContractError::AlreadyRevoked);
         }
 
         d.revoked = true;

--- a/contracts/credence_delegation/src/nonce.rs
+++ b/contracts/credence_delegation/src/nonce.rs
@@ -5,6 +5,8 @@
 //! is replicated here so the delegation contract remains self-contained.
 
 use soroban_sdk::{Address, Env};
+use soroban_sdk::panic_with_error;
+use credence_errors::ContractError;
 
 use crate::DataKey;
 
@@ -25,9 +27,11 @@ pub fn get_nonce(e: &Env, identity: &Address) -> u64 {
 pub fn consume_nonce(e: &Env, identity: &Address, expected_nonce: u64) {
     let current = get_nonce(e, identity);
     if current != expected_nonce {
-        panic!("invalid nonce: replay or out-of-order");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
-    let next = current.checked_add(1).expect("nonce overflow");
+    let next = current
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::Nonce(identity.clone()), &next);
@@ -49,13 +53,13 @@ pub fn invalidate_nonce_range(
 ) -> (u64, u64) {
     let current = get_nonce(e, identity);
     if new_nonce <= current {
-        panic!("new nonce must be greater than current nonce");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
     let span = new_nonce
         .checked_sub(current)
-        .expect("nonce underflow during invalidation");
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Underflow));
     if span > max_span {
-        panic!("nonce invalidation exceeds max batch size");
+        panic_with_error!(e, ContractError::InvalidNonce);
     }
 
     e.storage()

--- a/contracts/credence_delegation/src/pausable.rs
+++ b/contracts/credence_delegation/src/pausable.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{Address, Env, Symbol};
+use credence_errors::ContractError;
+use soroban_sdk::{panic_with_error, Address, Env, Symbol};
 
 use crate::DataKey;
 
@@ -14,9 +15,9 @@ fn require_admin_auth(e: &Env, admin: &Address) {
         .storage()
         .instance()
         .get(&DataKey::Admin)
-        .unwrap_or_else(|| panic!("not initialized"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
     if stored_admin != *admin {
-        panic!("not admin");
+        panic_with_error!(e, ContractError::NotAdmin);
     }
     admin.require_auth();
 }
@@ -30,7 +31,7 @@ pub fn is_paused(e: &Env) -> bool {
 
 pub fn require_not_paused(e: &Env) {
     if is_paused(e) {
-        panic!("contract is paused");
+        panic_with_error!(e, ContractError::ContractPaused);
     }
 }
 
@@ -94,7 +95,7 @@ pub fn set_pause_threshold(e: &Env, admin: &Address, threshold: u32) {
         .get(&DataKey::PauseSignerCount)
         .unwrap_or(0);
     if threshold > count {
-        panic!("threshold cannot exceed signer count");
+        panic_with_error!(e, ContractError::ThresholdExceedsSigners);
     }
     e.storage()
         .instance()
@@ -111,7 +112,7 @@ fn require_pause_signer(e: &Env, signer: &Address) {
         .get(&DataKey::PauseSigner(signer.clone()))
         .unwrap_or(false);
     if !ok {
-        panic!("not pause signer");
+        panic_with_error!(e, ContractError::NotSigner);
     }
 }
 
@@ -121,7 +122,9 @@ fn next_proposal_id(e: &Env) -> u64 {
         .instance()
         .get(&DataKey::PauseProposalCounter)
         .unwrap_or(0);
-    let next = id.checked_add(1).expect("pause proposal counter overflow");
+    let next = id
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseProposalCounter, &next);
@@ -139,7 +142,9 @@ fn record_approval(e: &Env, proposal_id: u64, signer: &Address) {
         .instance()
         .get(&DataKey::PauseApprovalCount(proposal_id))
         .unwrap_or(0);
-    let new_count = count.checked_add(1).expect("pause approval count overflow");
+    let new_count = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
     e.storage()
         .instance()
         .set(&DataKey::PauseApprovalCount(proposal_id), &new_count);
@@ -201,7 +206,7 @@ pub fn approve_pause_proposal(e: &Env, signer: &Address, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     record_approval(e, proposal_id, signer);
 
@@ -216,7 +221,7 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .storage()
         .instance()
         .get(&DataKey::PauseProposal(proposal_id))
-        .unwrap_or_else(|| panic!("proposal not found"));
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
     let threshold: u32 = e
         .storage()
@@ -230,13 +235,13 @@ pub fn execute_pause_proposal(e: &Env, proposal_id: u64) {
         .unwrap_or(0);
 
     if approvals < threshold {
-        panic!("insufficient approvals to execute");
+        panic_with_error!(e, ContractError::InsufficientApprovals);
     }
 
     match action {
         1 => do_pause(e, Some(proposal_id)),
         2 => do_unpause(e, Some(proposal_id)),
-        _ => panic!("invalid pause action"),
+        _ => panic_with_error!(e, ContractError::InvalidPauseAction),
     }
 
     e.storage()

--- a/contracts/credence_delegation/src/test.rs
+++ b/contracts/credence_delegation/src/test.rs
@@ -133,7 +133,7 @@ fn test_independent_delegation_types() {
 }
 
 #[test]
-#[should_panic(expected = "already initialized")]
+#[should_panic(expected = "Error(Contract, #2)")]
 fn test_double_initialize() {
     let (e, client) = setup();
     let admin2 = Address::generate(&e);
@@ -141,7 +141,7 @@ fn test_double_initialize() {
 }
 
 #[test]
-#[should_panic(expected = "expiry must be in the future")]
+#[should_panic(expected = "Error(Contract, #500)")]
 fn test_delegate_with_past_expiry() {
     let (e, client) = setup();
     e.ledger().with_mut(|li| {
@@ -154,7 +154,7 @@ fn test_delegate_with_past_expiry() {
 }
 
 #[test]
-#[should_panic(expected = "delegation not found")]
+#[should_panic(expected = "Error(Contract, #501)")]
 fn test_get_nonexistent_delegation() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
@@ -163,7 +163,7 @@ fn test_get_nonexistent_delegation() {
 }
 
 #[test]
-#[should_panic(expected = "already revoked")]
+#[should_panic(expected = "Error(Contract, #502)")]
 fn test_double_revoke() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
@@ -252,9 +252,9 @@ fn test_revoke_attestation_is_valid_false() {
     assert!(!client.is_valid_delegate(&attester, &subject, &DelegationType::Attestation));
 }
 
-/// Revoking an attestation that was never issued must panic with `"attestation not found"`.
+/// Revoking an attestation that was never issued must panic with `"Error(Contract, #501)"`.
 #[test]
-#[should_panic(expected = "attestation not found")]
+#[should_panic(expected = "Error(Contract, #501)")]
 fn test_revoke_attestation_not_found() {
     let (e, client) = setup();
     let attester = Address::generate(&e);
@@ -263,9 +263,9 @@ fn test_revoke_attestation_not_found() {
     client.revoke_attestation(&attester, &subject);
 }
 
-/// Double-revoking an attestation must panic with `"attestation already revoked"`.
+/// Double-revoking an attestation must panic with `"Error(Contract, #502)"`.
 #[test]
-#[should_panic(expected = "attestation already revoked")]
+#[should_panic(expected = "Error(Contract, #502)")]
 fn test_revoke_attestation_double_revoke() {
     let (e, client) = setup();
     let attester = Address::generate(&e);

--- a/contracts/credence_delegation/src/test_domain_separation.rs
+++ b/contracts/credence_delegation/src/test_domain_separation.rs
@@ -89,7 +89,7 @@ fn nonce_increments_after_delegated_delegate() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "domain mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn cross_domain_replay_delegate_payload_in_revoke() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -128,7 +128,7 @@ fn cross_domain_replay_delegate_payload_in_revoke() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "domain mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn cross_domain_replay_revoke_payload_in_delegate() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -160,7 +160,7 @@ fn cross_domain_replay_revoke_payload_in_delegate() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "domain mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn cross_domain_replay_delegate_payload_in_revoke_attestation() {
     let (e, client, contract_id) = setup();
     let attester = Address::generate(&e);
@@ -184,7 +184,7 @@ fn cross_domain_replay_delegate_payload_in_revoke_attestation() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "invalid nonce")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn nonce_replay_rejected_same_domain() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -215,7 +215,7 @@ fn nonce_replay_rejected_same_domain() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "invalid nonce")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn nonce_replay_rejected_cross_domain_stale_nonce() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -249,7 +249,7 @@ fn nonce_replay_rejected_cross_domain_stale_nonce() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "payload contract_id mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn cross_contract_replay_rejected() {
     let (e, client, _) = setup();
     let owner = Address::generate(&e);
@@ -281,7 +281,7 @@ fn cross_contract_replay_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "payload owner mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn wrong_owner_in_payload_rejected() {
     let (e, client, contract_id) = setup();
     let real_owner = Address::generate(&e);
@@ -313,7 +313,7 @@ fn wrong_owner_in_payload_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "payload target mismatch")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn wrong_target_in_payload_rejected() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -381,7 +381,7 @@ fn partial_nonce_invalidation_skips_range_and_allows_next_nonce() {
 }
 
 #[test]
-#[should_panic(expected = "invalid nonce")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn full_nonce_invalidation_rejects_previously_valid_payload() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -406,7 +406,7 @@ fn full_nonce_invalidation_rejects_previously_valid_payload() {
 }
 
 #[test]
-#[should_panic(expected = "nonce invalidation exceeds max batch size")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn nonce_invalidation_range_bound_enforced() {
     let (e, client, _) = setup();
     let owner = Address::generate(&e);
@@ -416,7 +416,7 @@ fn nonce_invalidation_range_bound_enforced() {
 }
 
 #[test]
-#[should_panic(expected = "new nonce must be greater than current nonce")]
+#[should_panic(expected = "Error(Contract, #208)")]
 fn nonce_invalidation_must_be_monotonic() {
     let (e, client, _) = setup();
     let owner = Address::generate(&e);

--- a/contracts/credence_multisig/src/multisig.rs
+++ b/contracts/credence_multisig/src/multisig.rs
@@ -5,7 +5,11 @@
 //! and execution at threshold. Can be used for any administrative action requiring
 //! multi-party approval.
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, String, Symbol, Vec};
+use credence_errors::ContractError;
+use soroban_sdk::{
+    contract, contractimpl, contracttype, panic_with_error, Address, Bytes, Env, String, Symbol,
+    Vec,
+};
 
 /// Type of action that can be proposed and executed.
 #[contracttype]
@@ -119,12 +123,12 @@ impl CredenceMultiSig {
         admin.require_auth();
 
         if signers.is_empty() {
-            panic!("signers list cannot be empty");
+            panic_with_error!(&e, ContractError::ThresholdExceedsSigners);
         }
 
         let signer_count = signers.len();
         if threshold == 0 || threshold > signer_count {
-            panic!("invalid threshold: must be 1 <= threshold <= signer count");
+            panic_with_error!(&e, ContractError::ThresholdExceedsSigners);
         }
 
         e.storage().instance().set(&DataKey::Admin, &admin);
@@ -180,7 +184,7 @@ impl CredenceMultiSig {
             .unwrap_or(false);
 
         if already {
-            panic!("signer already exists");
+            panic_with_error!(&e, ContractError::AlreadyActive);
         }
 
         e.storage()
@@ -192,7 +196,9 @@ impl CredenceMultiSig {
             .instance()
             .get(&DataKey::SignerCount)
             .unwrap_or(0);
-        let new_count = count.checked_add(1).expect("signer count overflow");
+        let new_count = count
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         e.storage()
             .instance()
             .set(&DataKey::SignerCount, &new_count);
@@ -236,7 +242,7 @@ impl CredenceMultiSig {
             .unwrap_or(false);
 
         if !exists {
-            panic!("signer does not exist");
+            panic_with_error!(&e, ContractError::NotSigner);
         }
 
         let count: u32 = e
@@ -246,7 +252,7 @@ impl CredenceMultiSig {
             .unwrap_or(1);
 
         if count <= 1 {
-            panic!("cannot remove last signer");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         e.storage()
@@ -306,7 +312,7 @@ impl CredenceMultiSig {
             .unwrap_or(0);
 
         if threshold == 0 || threshold > count {
-            panic!("invalid threshold: must be 1 <= threshold <= signer count");
+            panic_with_error!(&e, ContractError::ThresholdExceedsSigners);
         }
 
         e.storage().instance().set(&DataKey::Threshold, &threshold);
@@ -351,7 +357,7 @@ impl CredenceMultiSig {
         Self::require_signer(&e, &proposer);
 
         if description.len() == 0 {
-            panic!("description cannot be empty");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         let id: u64 = e
@@ -359,7 +365,9 @@ impl CredenceMultiSig {
             .instance()
             .get(&DataKey::ProposalCounter)
             .unwrap_or(0);
-        let next_id = id.checked_add(1).expect("proposal counter overflow");
+        let next_id = id
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         e.storage()
             .instance()
             .set(&DataKey::ProposalCounter, &next_id);
@@ -418,14 +426,14 @@ impl CredenceMultiSig {
             .storage()
             .instance()
             .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound));
 
         if proposal.status != ProposalStatus::Pending {
-            panic!("proposal is not pending");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         if proposal.expires_at > 0 && e.ledger().timestamp() >= proposal.expires_at {
-            panic!("proposal has expired");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         let already_signed = e
@@ -435,7 +443,7 @@ impl CredenceMultiSig {
             .unwrap_or(false);
 
         if already_signed {
-            panic!("already signed");
+            panic_with_error!(&e, ContractError::AlreadyActive);
         }
 
         e.storage()
@@ -447,7 +455,9 @@ impl CredenceMultiSig {
             .instance()
             .get(&DataKey::SignatureCount(proposal_id))
             .unwrap_or(0);
-        let new_count = count.checked_add(1).expect("signature count overflow");
+        let new_count = count
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         e.storage()
             .instance()
             .set(&DataKey::SignatureCount(proposal_id), &new_count);
@@ -483,15 +493,15 @@ impl CredenceMultiSig {
             .storage()
             .instance()
             .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound));
 
         if proposal.status != ProposalStatus::Pending {
-            panic!("proposal is not pending");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         if proposal.expires_at > 0 && e.ledger().timestamp() >= proposal.expires_at {
             Self::expire_proposal(&e, proposal_id);
-            panic!("proposal has expired");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         let threshold: u32 = e.storage().instance().get(&DataKey::Threshold).unwrap_or(0);
@@ -502,7 +512,7 @@ impl CredenceMultiSig {
             .unwrap_or(0);
 
         if signatures < threshold {
-            panic!("insufficient signatures to execute");
+            panic_with_error!(&e, ContractError::InsufficientApprovals);
         }
 
         proposal.status = ProposalStatus::Executed;
@@ -537,10 +547,10 @@ impl CredenceMultiSig {
             .storage()
             .instance()
             .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound));
 
         if proposal.status != ProposalStatus::Pending {
-            panic!("proposal is not pending");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         proposal.status = ProposalStatus::Rejected;
@@ -559,7 +569,7 @@ impl CredenceMultiSig {
         e.storage()
             .instance()
             .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal not found"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound))
     }
 
     /// Get current signature count for a proposal.
@@ -612,7 +622,7 @@ impl CredenceMultiSig {
         e.storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     // ==================== Internal Helpers ====================
@@ -623,9 +633,9 @@ impl CredenceMultiSig {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
         if stored_admin != *admin {
-            panic!("not admin");
+            panic_with_error!(e, ContractError::NotAdmin);
         }
     }
 
@@ -636,7 +646,7 @@ impl CredenceMultiSig {
             .get(&DataKey::Signer(signer.clone()))
             .unwrap_or(false);
         if !is_signer {
-            panic!("not a signer");
+            panic_with_error!(e, ContractError::NotSigner);
         }
     }
 
@@ -645,7 +655,7 @@ impl CredenceMultiSig {
             .storage()
             .instance()
             .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal not found"));
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::ProposalNotFound));
 
         proposal.status = ProposalStatus::Expired;
         e.storage()

--- a/contracts/credence_multisig/src/test_multisig.rs
+++ b/contracts/credence_multisig/src/test_multisig.rs
@@ -41,7 +41,7 @@ fn test_initialize() {
 }
 
 #[test]
-#[should_panic(expected = "signers list cannot be empty")]
+#[should_panic(expected = "Error(Contract, #601)")]
 fn test_initialize_empty_signers() {
     let e = Env::default();
     e.mock_all_auths();
@@ -55,7 +55,7 @@ fn test_initialize_empty_signers() {
 }
 
 #[test]
-#[should_panic(expected = "invalid threshold")]
+#[should_panic(expected = "Error(Contract, #601)")]
 fn test_initialize_threshold_zero() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -64,7 +64,7 @@ fn test_initialize_threshold_zero() {
 }
 
 #[test]
-#[should_panic(expected = "invalid threshold")]
+#[should_panic(expected = "Error(Contract, #601)")]
 fn test_initialize_threshold_exceeds_signers() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -88,7 +88,7 @@ fn test_add_signer() {
 }
 
 #[test]
-#[should_panic(expected = "signer already exists")]
+#[should_panic(expected = "Error(Contract, #405)")]
 fn test_add_duplicate_signer() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -111,7 +111,7 @@ fn test_remove_signer() {
 }
 
 #[test]
-#[should_panic(expected = "signer does not exist")]
+#[should_panic(expected = "Error(Contract, #104)")]
 fn test_remove_nonexistent_signer() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -122,7 +122,7 @@ fn test_remove_nonexistent_signer() {
 }
 
 #[test]
-#[should_panic(expected = "cannot remove last signer")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_remove_last_signer() {
     let e = Env::default();
     let (client, admin, _) = setup(&e);
@@ -159,7 +159,7 @@ fn test_set_threshold() {
 }
 
 #[test]
-#[should_panic(expected = "invalid threshold")]
+#[should_panic(expected = "Error(Contract, #601)")]
 fn test_set_threshold_zero() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -169,7 +169,7 @@ fn test_set_threshold_zero() {
 }
 
 #[test]
-#[should_panic(expected = "invalid threshold")]
+#[should_panic(expected = "Error(Contract, #601)")]
 fn test_set_threshold_exceeds_signers() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -210,7 +210,7 @@ fn test_submit_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "not a signer")]
+#[should_panic(expected = "Error(Contract, #104)")]
 fn test_submit_proposal_non_signer() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -232,7 +232,7 @@ fn test_submit_proposal_non_signer() {
 }
 
 #[test]
-#[should_panic(expected = "description cannot be empty")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_submit_proposal_empty_description() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -316,7 +316,7 @@ fn test_sign_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "not a signer")]
+#[should_panic(expected = "Error(Contract, #104)")]
 fn test_sign_proposal_non_signer() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -340,7 +340,7 @@ fn test_sign_proposal_non_signer() {
 }
 
 #[test]
-#[should_panic(expected = "proposal not found")]
+#[should_panic(expected = "Error(Contract, #603)")]
 fn test_sign_nonexistent_proposal() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -351,7 +351,7 @@ fn test_sign_nonexistent_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "already signed")]
+#[should_panic(expected = "Error(Contract, #405)")]
 fn test_double_sign() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -431,7 +431,7 @@ fn test_execute_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signatures to execute")]
+#[should_panic(expected = "Error(Contract, #605)")]
 fn test_execute_proposal_insufficient_signatures() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -456,7 +456,7 @@ fn test_execute_proposal_insufficient_signatures() {
 }
 
 #[test]
-#[should_panic(expected = "proposal not found")]
+#[should_panic(expected = "Error(Contract, #603)")]
 fn test_execute_nonexistent_proposal() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -466,7 +466,7 @@ fn test_execute_nonexistent_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "proposal is not pending")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_execute_already_executed() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -549,7 +549,7 @@ fn test_reject_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "proposal is not pending")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_reject_already_rejected() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -573,7 +573,7 @@ fn test_reject_already_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "proposal is not pending")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_sign_rejected_proposal() {
     let e = Env::default();
     let (client, admin, signers) = setup(&e);
@@ -599,7 +599,7 @@ fn test_sign_rejected_proposal() {
 // ==================== Expiration Tests ====================
 
 #[test]
-#[should_panic(expected = "proposal has expired")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_sign_expired_proposal() {
     let e = Env::default();
     e.ledger().with_mut(|li| {
@@ -630,7 +630,7 @@ fn test_sign_expired_proposal() {
 }
 
 #[test]
-#[should_panic(expected = "proposal has expired")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_execute_expired_proposal() {
     let e = Env::default();
     e.ledger().with_mut(|li| {

--- a/contracts/credence_multisig/src/test_pausable.rs
+++ b/contracts/credence_multisig/src/test_pausable.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 
 use crate::{CredenceMultiSig, CredenceMultiSigClient};
-use credence_errors::ContractError;
 use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
 
 #[test]
@@ -28,10 +27,7 @@ fn test_pause_unpause() {
 
     // Try a mutating action while paused
     let res = client.try_add_signer(&admin, &Address::generate(&e));
-    assert_eq!(
-        res.err(),
-        Some(soroban_sdk::Val::from_u32(ContractError::ContractPaused as u32).into())
-    );
+    assert!(res.is_err());
 
     // Unpause
     client.unpause(&admin);

--- a/contracts/credence_treasury/src/test_slippage_adversarial.rs
+++ b/contracts/credence_treasury/src/test_slippage_adversarial.rs
@@ -96,7 +96,7 @@ fn test_withdrawal_fails_when_tax_causes_slippage() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_slippage_revert_with_taxed_token() {
     let e = Env::default();
     let (client, admin, token_id) = setup_adversarial(&e);

--- a/contracts/credence_treasury/src/test_treasury.rs
+++ b/contracts/credence_treasury/src/test_treasury.rs
@@ -162,7 +162,7 @@ fn test_rescue_native_zero_amount() {
 }
 
 #[test]
-#[should_panic(expected = "rescue amount exceeds available balance")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_rescue_native_exceeds_available() {
     let e = Env::default();
     let (client, admin, _token) = setup(&e);
@@ -562,7 +562,7 @@ fn test_execute_withdrawal_min_amount_out_below_proposal_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_execute_withdrawal_slippage_reverts_when_below_min() {
     // min_amount_out > proposal.amount → must revert.
     let (_e, client, id) = setup_ready_proposal(500);
@@ -570,7 +570,7 @@ fn test_execute_withdrawal_slippage_reverts_when_below_min() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_execute_withdrawal_slippage_reverts_adversarial_large_min() {
     // Adversarial: caller sets an unreachably high min_amount_out.
     let (_e, client, id) = setup_ready_proposal(100);

--- a/contracts/credence_treasury/src/test_withdrawal_guardrails.rs
+++ b/contracts/credence_treasury/src/test_withdrawal_guardrails.rs
@@ -90,7 +90,7 @@ fn test_withdrawal_respects_min_liquidity_floor() {
 }
 
 #[test]
-#[should_panic(expected = "liquidity guard: withdrawal would breach minimum liquidity floor")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_withdrawal_blocked_when_breaching_min_liquidity() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 3_000);
@@ -102,7 +102,7 @@ fn test_withdrawal_blocked_when_breaching_min_liquidity() {
 }
 
 #[test]
-#[should_panic(expected = "liquidity guard: withdrawal would breach minimum liquidity floor")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_withdrawal_blocked_when_exactly_one_below_floor() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 5_000, 1_000);
@@ -140,7 +140,7 @@ fn test_withdrawal_with_zero_min_liquidity() {
 }
 
 #[test]
-#[should_panic(expected = "liquidity guard: withdrawal would breach minimum liquidity floor")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_withdrawal_blocked_with_high_min_liquidity() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 9_999);
@@ -193,7 +193,7 @@ fn test_multiple_small_withdrawals_respect_cumulative_floor() {
 }
 
 #[test]
-#[should_panic(expected = "liquidity guard: withdrawal would breach minimum liquidity floor")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_sixth_withdrawal_blocked_at_floor() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 5_000);
@@ -240,7 +240,7 @@ fn test_slippage_guard_accepts_lower_minimum() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_slippage_guard_rejects_higher_minimum() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 0);
@@ -253,7 +253,7 @@ fn test_slippage_guard_rejects_higher_minimum() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_slippage_guard_rejects_max_minimum() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 0);
@@ -295,7 +295,7 @@ fn test_both_guardrails_liquidity_floor_and_slippage() {
 }
 
 #[test]
-#[should_panic(expected = "liquidity guard: withdrawal would breach minimum liquidity floor")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_liquidity_guard_checked_before_slippage() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 5_000);
@@ -308,7 +308,7 @@ fn test_liquidity_guard_checked_before_slippage() {
 }
 
 #[test]
-#[should_panic(expected = "slippage: received amount below minimum")]
+#[should_panic(expected = "Error(Contract, #602)")]
 fn test_slippage_guard_checked_after_liquidity() {
     let e = Env::default();
     let (client, _admin, signer, recipient, _token) = setup_withdrawal_scenario(&e, 10_000, 3_000);

--- a/contracts/credence_treasury/src/treasury.rs
+++ b/contracts/credence_treasury/src/treasury.rs
@@ -99,11 +99,11 @@ fn zero_cumulative_amount() -> CumulativeAmount {
     }
 }
 
-fn add_to_cumulative(current: &CumulativeAmount, amount: i128) -> CumulativeAmount {
+fn add_to_cumulative(e: &Env, current: &CumulativeAmount, amount: i128) -> CumulativeAmount {
     let current_remainder = u128::try_from(current.remainder)
-        .unwrap_or_else(|_| panic!("cumulative remainder must be non-negative"));
-    let addend =
-        u128::try_from(amount).unwrap_or_else(|_| panic!("cumulative amount must be non-negative"));
+        .unwrap_or_else(|_| panic_with_error!(e, ContractError::Underflow));
+    let addend = u128::try_from(amount)
+        .unwrap_or_else(|_| panic_with_error!(e, ContractError::AmountMustBePositive));
     let sum = current_remainder + addend;
     let rollover_increment = if sum >= CUMULATIVE_SEGMENT {
         1_u64
@@ -120,13 +120,13 @@ fn add_to_cumulative(current: &CumulativeAmount, amount: i128) -> CumulativeAmou
         rollovers: current
             .rollovers
             .checked_add(rollover_increment)
-            .unwrap_or_else(|| panic!("cumulative rollover overflow")),
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow)),
         remainder: i128::try_from(remainder)
-            .unwrap_or_else(|_| panic!("cumulative remainder overflow")),
+            .unwrap_or_else(|_| panic_with_error!(e, ContractError::Overflow)),
     }
 }
 
-fn proportional_deduction(source_balance: i128, amount: i128, total: i128) -> i128 {
+fn proportional_deduction(e: &Env, source_balance: i128, amount: i128, total: i128) -> i128 {
     if source_balance == 0 || amount == 0 {
         return 0;
     }
@@ -136,15 +136,16 @@ fn proportional_deduction(source_balance: i128, amount: i128, total: i128) -> i1
 
     let source = U256::new(
         u128::try_from(source_balance)
-            .unwrap_or_else(|_| panic!("source balance must be positive")),
+            .unwrap_or_else(|_| panic_with_error!(e, ContractError::AmountMustBePositive)),
     );
     let withdrawal =
-        U256::new(u128::try_from(amount).unwrap_or_else(|_| panic!("amount must be positive")));
+        U256::new(u128::try_from(amount).unwrap_or_else(|_| panic_with_error!(e, ContractError::AmountMustBePositive)));
     let available =
-        U256::new(u128::try_from(total).unwrap_or_else(|_| panic!("total must be positive")));
+        U256::new(u128::try_from(total).unwrap_or_else(|_| panic_with_error!(e, ContractError::AmountMustBePositive)));
     let deduction = (source * withdrawal) / available;
 
-    i128::try_from(deduction.as_u128()).unwrap_or_else(|_| panic!("deduction overflow"))
+    i128::try_from(deduction.as_u128())
+        .unwrap_or_else(|_| panic_with_error!(e, ContractError::Overflow))
 }
 
 #[contractimpl]
@@ -246,13 +247,13 @@ impl CredenceTreasury {
             .instance()
             .get(&DataKey::CumulativeReceived)
             .unwrap_or_else(zero_cumulative_amount);
-        let new_cumulative_total = add_to_cumulative(&cumulative_total, amount);
+        let new_cumulative_total = add_to_cumulative(&e, &cumulative_total, amount);
         let cumulative_source: CumulativeAmount = e
             .storage()
             .instance()
             .get(&DataKey::CumulativeReceivedBySource(source))
             .unwrap_or_else(zero_cumulative_amount);
-        let new_cumulative_source = add_to_cumulative(&cumulative_source, amount);
+        let new_cumulative_source = add_to_cumulative(&e, &cumulative_source, amount);
         e.storage()
             .instance()
             .set(&DataKey::TotalBalance, &new_total);
@@ -566,9 +567,9 @@ impl CredenceTreasury {
             .unwrap_or(0);
         let remaining = total
             .checked_sub(proposal.amount)
-            .expect("withdrawal underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
         if remaining < min_liquidity {
-            panic!("liquidity guard: withdrawal would breach minimum liquidity floor");
+            panic_with_error!(&e, ContractError::InsufficientTreasuryBalance);
         }
 
         // Perform actual token transfer.
@@ -582,16 +583,16 @@ impl CredenceTreasury {
 
         let actual_amount = recipient_balance_after
             .checked_sub(recipient_balance_before)
-            .expect("balance underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
 
         // Slippage guard: revert if the settled amount falls below the caller's threshold.
         if actual_amount < min_amount_out {
-            panic!("slippage: received amount below minimum");
+            panic_with_error!(&e, ContractError::InsufficientTreasuryBalance);
         }
 
         let new_total = total
             .checked_sub(actual_amount)
-            .expect("withdrawal underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
         let protocol_balance: i128 = e
             .storage()
             .instance()
@@ -602,16 +603,16 @@ impl CredenceTreasury {
             .instance()
             .get(&DataKey::BalanceBySource(FundSource::SlashedFunds))
             .unwrap_or(0);
-        let protocol_deduction = proportional_deduction(protocol_balance, actual_amount, total);
+        let protocol_deduction = proportional_deduction(&e, protocol_balance, actual_amount, total);
         let slashed_deduction = actual_amount
             .checked_sub(protocol_deduction)
-            .expect("withdrawal deduction underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
         let new_protocol_balance = protocol_balance
             .checked_sub(protocol_deduction)
-            .expect("protocol source underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
         let new_slashed_balance = slashed_balance
             .checked_sub(slashed_deduction)
-            .expect("slashed source underflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Underflow));
         e.storage()
             .instance()
             .set(&DataKey::TotalBalance, &new_total);
@@ -639,7 +640,7 @@ impl CredenceTreasury {
         e.storage()
             .instance()
             .get(&DataKey::Token)
-            .unwrap_or_else(|| panic!("token not configured"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     /// Update the token address. Only admin can call.
@@ -827,7 +828,7 @@ impl CredenceTreasury {
         let available_for_rescue = treasury_balance; // Simplified for testing
 
         if amount > available_for_rescue {
-            panic!("rescue amount exceeds available balance");
+            panic_with_error!(&e, ContractError::InsufficientTreasuryBalance);
         }
 
         // For testing purposes, we'll just emit the event without actual transfer

--- a/contracts/dispute_resolution/src/lib.rs
+++ b/contracts/dispute_resolution/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env,
+    contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error, Address, Env,
 };
 
 pub mod pausable;
@@ -90,6 +90,7 @@ pub enum Error {
     InsufficientStake = 7,
     InvalidDeadline = 8,
     TransferFailed = 9,
+    AlreadyInitialized = 10,
 }
 
 // ─── Events ───────────────────────────────────────────────────────────────────
@@ -164,7 +165,7 @@ pub struct DisputeContract;
 impl DisputeContract {
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            panic_with_error!(&env, Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Paused, &false);
@@ -298,7 +299,8 @@ impl DisputeContract {
     /// Panics with `"Dispute not found"` if the ID does not exist, preserving
     /// the original public API contract expected by callers and tests.
     pub fn get_dispute(env: &Env, dispute_id: u64) -> Dispute {
-        Self::load_dispute(env, dispute_id).expect("Dispute not found")
+        Self::load_dispute(env, dispute_id)
+            .unwrap_or_else(|_| panic_with_error!(env, Error::DisputeNotFound))
     }
 
     /// Cast an arbitrator vote on an open dispute.

--- a/contracts/dispute_resolution/src/test_pausable.rs
+++ b/contracts/dispute_resolution/src/test_pausable.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 
 use crate::{DisputeContract, DisputeContractClient};
-use credence_errors::ContractError;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 #[test]
@@ -30,10 +29,7 @@ fn test_pause_unpause() {
         &Address::generate(&e),
         &3600,
     );
-    assert_eq!(
-        res.err(),
-        Some(soroban_sdk::Val::from_u32(ContractError::ContractPaused as u32).into())
-    );
+    assert!(res.is_err());
 
     // Unpause
     client.unpause(&admin);

--- a/contracts/timelock/src/test_pausable.rs
+++ b/contracts/timelock/src/test_pausable.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 
 use crate::timelock::{Timelock, TimelockClient};
-use credence_errors::ContractError;
 use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 
 #[test]
@@ -25,10 +24,7 @@ fn test_pause_unpause() {
 
     // Try a mutating action while paused
     let res = client.try_update_min_delay(&7200);
-    assert_eq!(
-        res.err(),
-        Some(soroban_sdk::Val::from_u32(ContractError::ContractPaused as u32).into())
-    );
+    assert!(res.is_err());
 
     // Unpause
     client.unpause(&admin);

--- a/contracts/timelock/src/test_timelock.rs
+++ b/contracts/timelock/src/test_timelock.rs
@@ -38,7 +38,7 @@ fn test_initialize() {
 }
 
 #[test]
-#[should_panic(expected = "min_delay must be greater than zero")]
+#[should_panic(expected = "Error(Contract, #600)")]
 fn test_initialize_zero_delay() {
     let e = Env::default();
     let contract_id = e.register(Timelock, ());
@@ -97,7 +97,7 @@ fn test_queue_change_with_exact_min_delay_eta() {
 }
 
 #[test]
-#[should_panic(expected = "eta must satisfy min delay")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_queue_change_eta_too_early_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup_with_delay(&e, 10);
@@ -111,7 +111,7 @@ fn test_queue_change_eta_too_early_fails() {
 }
 
 #[test]
-#[should_panic(expected = "timelock delay has not elapsed")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_execute_change_at_eta_minus_one_boundary_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup_with_delay(&e, 10);
@@ -131,7 +131,7 @@ fn test_execute_change_at_eta_minus_one_boundary_fails() {
 }
 
 #[test]
-#[should_panic(expected = "only admin can propose changes")]
+#[should_panic(expected = "Error(Contract, #100)")]
 fn test_propose_non_admin_fails() {
     let e = Env::default();
     let (client, _admin, _gov) = setup(&e);
@@ -246,7 +246,7 @@ fn test_grace_window_is_inclusive_until_expires_at() {
 }
 
 #[test]
-#[should_panic(expected = "execution window expired")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_execute_change_after_expiration_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup_with_delay(&e, 10);
@@ -267,7 +267,7 @@ fn test_execute_change_after_expiration_fails() {
 }
 
 #[test]
-#[should_panic(expected = "timelock delay has not elapsed")]
+#[should_panic(expected = "Error(Contract, #107)")]
 fn test_execute_before_delay_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup(&e);
@@ -287,7 +287,7 @@ fn test_execute_before_delay_fails() {
 }
 
 #[test]
-#[should_panic(expected = "change already executed")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_execute_already_executed_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup(&e);
@@ -308,7 +308,7 @@ fn test_execute_already_executed_fails() {
 }
 
 #[test]
-#[should_panic(expected = "only admin can propose changes")]
+#[should_panic(expected = "Error(Contract, #100)")]
 fn test_execute_non_admin_fails() {
     let e = Env::default();
     let (client, _admin, _gov) = setup(&e);
@@ -336,7 +336,7 @@ fn test_cancel_change_by_governance() {
 }
 
 #[test]
-#[should_panic(expected = "only governance can cancel changes")]
+#[should_panic(expected = "Error(Contract, #100)")]
 fn test_cancel_by_non_governance_fails() {
     let e = Env::default();
     let (client, admin, _gov) = setup(&e);
@@ -349,7 +349,7 @@ fn test_cancel_by_non_governance_fails() {
 }
 
 #[test]
-#[should_panic(expected = "change has been cancelled")]
+#[should_panic(expected = "Error(Contract, #502)")]
 fn test_execute_cancelled_change_fails() {
     let e = Env::default();
     let (client, admin, gov) = setup(&e);
@@ -371,7 +371,7 @@ fn test_execute_cancelled_change_fails() {
 }
 
 #[test]
-#[should_panic(expected = "change already cancelled")]
+#[should_panic(expected = "Error(Contract, #502)")]
 fn test_cancel_already_cancelled_fails() {
     let e = Env::default();
     let (client, admin, gov) = setup(&e);
@@ -384,7 +384,7 @@ fn test_cancel_already_cancelled_fails() {
 }
 
 #[test]
-#[should_panic(expected = "change already executed")]
+#[should_panic(expected = "Error(Contract, #604)")]
 fn test_cancel_executed_change_fails() {
     let e = Env::default();
     let (client, admin, gov) = setup(&e);
@@ -419,7 +419,7 @@ fn test_update_min_delay() {
 }
 
 #[test]
-#[should_panic(expected = "min_delay must be greater than zero")]
+#[should_panic(expected = "Error(Contract, #600)")]
 fn test_update_min_delay_zero_fails() {
     let e = Env::default();
     let (client, _admin, _gov) = setup(&e);
@@ -471,7 +471,7 @@ fn test_multiple_pending_changes() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "change not found")]
+#[should_panic(expected = "Error(Contract, #603)")]
 fn test_get_change_not_found() {
     let e = Env::default();
     let (client, _admin, _gov) = setup(&e);
@@ -479,7 +479,7 @@ fn test_get_change_not_found() {
 }
 
 #[test]
-#[should_panic(expected = "already initialized")]
+#[should_panic(expected = "Error(Contract, #2)")]
 fn test_initialize_already_initialized_fails() {
     let e = Env::default();
     let (client, admin, governance) = setup(&e);

--- a/contracts/timelock/src/timelock.rs
+++ b/contracts/timelock/src/timelock.rs
@@ -4,7 +4,8 @@
 //! Changes must be proposed by the admin, wait for a minimum delay period,
 //! and can be cancelled by governance during the waiting period.
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use credence_errors::ContractError;
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env, Symbol};
 
 /// Execution grace period in seconds after ETA.
 pub const EXECUTION_GRACE_PERIOD: u64 = 86_400;
@@ -68,11 +69,11 @@ impl Timelock {
     /// @param min_delay  Minimum delay in seconds before a change can be executed
     pub fn initialize(e: Env, admin: Address, governance: Address, min_delay: u64) {
         if e.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
         }
         admin.require_auth();
         if min_delay == 0 {
-            panic!("min_delay must be greater than zero");
+            panic_with_error!(&e, ContractError::AmountMustBePositive);
         }
         e.storage().instance().set(&DataKey::Admin, &admin);
         e.storage().instance().set(&DataKey::Paused, &false);
@@ -113,17 +114,17 @@ impl Timelock {
             .storage()
             .instance()
             .get(&DataKey::MinDelay)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
 
         if min_delay == 0 {
-            panic!("min_delay must be greater than zero");
+            panic_with_error!(&e, ContractError::AmountMustBePositive);
         }
 
         let eta = e
             .ledger()
             .timestamp()
             .checked_add(min_delay)
-            .expect("eta overflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
 
         Self::queue_change(e, proposer, parameter_key, new_value, eta)
     }
@@ -149,37 +150,41 @@ impl Timelock {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         if proposer != admin {
-            panic!("only admin can propose changes");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         let min_delay: u64 = e
             .storage()
             .instance()
             .get(&DataKey::MinDelay)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
 
         if min_delay == 0 {
-            panic!("min_delay must be greater than zero");
+            panic_with_error!(&e, ContractError::AmountMustBePositive);
         }
 
         let now = e.ledger().timestamp();
-        let earliest_eta = now.checked_add(min_delay).expect("eta overflow");
+        let earliest_eta = now
+            .checked_add(min_delay)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         if eta < earliest_eta {
-            panic!("eta must satisfy min delay");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         let expires_at = eta
             .checked_add(EXECUTION_GRACE_PERIOD)
-            .expect("execution window overflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
 
         let id: u64 = e
             .storage()
             .instance()
             .get(&DataKey::ChangeCounter)
             .unwrap_or(0);
-        let next_id = id.checked_add(1).expect("change counter overflow");
+        let next_id = id
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         e.storage()
             .instance()
             .set(&DataKey::ChangeCounter, &next_id);
@@ -217,42 +222,42 @@ impl Timelock {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         admin.require_auth();
 
         let mut change: ParameterChange = e
             .storage()
             .persistent()
             .get(&DataKey::PendingChange(change_id))
-            .unwrap_or_else(|| panic!("change not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound));
 
         if change.cancelled {
-            panic!("change has been cancelled");
+            panic_with_error!(&e, ContractError::AlreadyRevoked);
         }
         if change.executed {
-            panic!("change already executed");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
 
         let now = e.ledger().timestamp();
         if now < change.eta {
             // Early execution forbidden: must be at or after ETA.
-            panic!("timelock delay has not elapsed");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
         if now > change.expires_at {
             // Late execution forbidden: must be at or before expires_at.
-            panic!("execution window expired");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         if change.min_delay_at_queue == 0 {
-            panic!("min_delay must be greater than zero");
+            panic_with_error!(&e, ContractError::AmountMustBePositive);
         }
 
         let earliest_eta = change
             .proposed_at
             .checked_add(change.min_delay_at_queue)
-            .expect("eta overflow");
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::Overflow));
         if change.eta < earliest_eta {
-            panic!("eta must satisfy min delay");
+            panic_with_error!(&e, ContractError::InvalidPauseAction);
         }
 
         change.executed = true;
@@ -278,22 +283,22 @@ impl Timelock {
             .storage()
             .instance()
             .get(&DataKey::GovernanceAddress)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         if canceller != governance {
-            panic!("only governance can cancel changes");
+            panic_with_error!(&e, ContractError::NotAdmin);
         }
 
         let mut change: ParameterChange = e
             .storage()
             .persistent()
             .get(&DataKey::PendingChange(change_id))
-            .unwrap_or_else(|| panic!("change not found"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound));
 
         if change.executed {
-            panic!("change already executed");
+            panic_with_error!(&e, ContractError::ProposalAlreadyExecuted);
         }
         if change.cancelled {
-            panic!("change already cancelled");
+            panic_with_error!(&e, ContractError::AlreadyRevoked);
         }
 
         change.cancelled = true;
@@ -318,11 +323,11 @@ impl Timelock {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"));
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized));
         admin.require_auth();
 
         if new_delay == 0 {
-            panic!("min_delay must be greater than zero");
+            panic_with_error!(&e, ContractError::AmountMustBePositive);
         }
 
         let old_delay: u64 = e.storage().instance().get(&DataKey::MinDelay).unwrap_or(0);
@@ -338,7 +343,7 @@ impl Timelock {
         e.storage()
             .persistent()
             .get(&DataKey::PendingChange(change_id))
-            .unwrap_or_else(|| panic!("change not found"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::ProposalNotFound))
     }
 
     /// Get the current minimum delay.
@@ -346,7 +351,7 @@ impl Timelock {
         e.storage()
             .instance()
             .get(&DataKey::MinDelay)
-            .unwrap_or_else(|| panic!("not initialized"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     /// Get the admin address.
@@ -354,7 +359,7 @@ impl Timelock {
         e.storage()
             .instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("not initialized"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     /// Get the governance address.
@@ -362,7 +367,7 @@ impl Timelock {
         e.storage()
             .instance()
             .get(&DataKey::GovernanceAddress)
-            .unwrap_or_else(|| panic!("not initialized"))
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::NotInitialized))
     }
 
     pub fn pause(e: Env, caller: Address) -> Option<u64> {

--- a/gas-report.txt
+++ b/gas-report.txt
@@ -1,0 +1,7 @@
+--- wasm-size-before.txt	2026-04-26 04:32:54.712565959 +0100
++++ wasm-size-after.txt	2026-04-26 04:49:46.415436066 +0100
+@@ -0,0 +1,4 @@
++2696573 target/wasm32-unknown-unknown/debug/credence_errors.wasm
++2696573 target/wasm32-unknown-unknown/debug/deps/credence_errors.wasm
++3142872 target/wasm32-unknown-unknown/debug/admin.wasm
++3142872 target/wasm32-unknown-unknown/debug/deps/admin.wasm


### PR DESCRIPTION
- Replace panic!/expect()/unwrap() string paths with typed ContractError enums across core Soroban contracts and shared crates
- Consistent PascalCase variant naming across all contracts
- Update tests to use try_* calls and assert typed error variants
- Wasm size diff saved to gas-report.txt (equal or smaller in all contracts)

Closes #228