### PR TITLE
refactor(credence_bond): centralize attestation type validation

### DIFF
--- a/contracts/credence_bond/src/lib.rs
+++ b/contracts/credence_bond/src/lib.rs
@@ -769,6 +769,9 @@ impl CredenceBond {
         attester.require_auth();
         require_verifier(&e, &attester);
 
+        // Validate raw attestation input before taking any stateful actions.
+        Attestation::validate_data(&attestation_data);
+
         // Verify attester is authorized
         let is_authorized: bool = e
             .storage()
@@ -798,6 +801,7 @@ impl CredenceBond {
             weight,
             revoked: false,
         };
+        attestation.validate();
         e.storage()
             .instance()
             .set(&DataKey::Attestation(id), &attestation);

--- a/contracts/credence_bond/src/test_attestation_types.rs
+++ b/contracts/credence_bond/src/test_attestation_types.rs
@@ -1,5 +1,6 @@
 //! Tests for Attestation data structure: validation, serialization, and dedup key.
 
+use alloc::string::String as StdString;
 use crate::types::attestation::{DEFAULT_ATTESTATION_WEIGHT, MAX_ATTESTATION_WEIGHT};
 use crate::types::{Attestation, AttestationDedupKey};
 use soroban_sdk::testutils::Address as _;
@@ -109,6 +110,25 @@ fn attestation_dedup_key_equality() {
         attestation_data: d,
     };
     assert_eq!(k1, k2);
+}
+
+#[test]
+#[should_panic(expected = "attestation data cannot be empty")]
+fn attestation_validate_rejects_empty_data() {
+    let e = Env::default();
+    let data = String::from_str(&e, "");
+    Attestation::validate_data(&data);
+}
+
+#[test]
+#[should_panic(expected = "attestation data exceeds maximum length")]
+fn attestation_validate_rejects_too_long_data() {
+    let e = Env::default();
+    let long_str: StdString = core::iter::repeat('a')
+        .take((MAX_ATTESTATION_DATA_LENGTH + 1) as usize)
+        .collect();
+    let data = String::from_str(&e, &long_str);
+    Attestation::validate_data(&data);
 }
 
 /// Serialization is exercised via add_attestation/get_attestation (contract storage) in test_attestation.

--- a/contracts/credence_bond/src/test_attestation_types.rs
+++ b/contracts/credence_bond/src/test_attestation_types.rs
@@ -1,7 +1,11 @@
 //! Tests for Attestation data structure: validation, serialization, and dedup key.
 
 use alloc::string::String as StdString;
-use crate::types::attestation::{DEFAULT_ATTESTATION_WEIGHT, MAX_ATTESTATION_WEIGHT};
+use crate::types::attestation::{
+    DEFAULT_ATTESTATION_WEIGHT,
+    MAX_ATTESTATION_DATA_LENGTH,
+    MAX_ATTESTATION_WEIGHT,
+};
 use crate::types::{Attestation, AttestationDedupKey};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Env, String};
@@ -35,6 +39,21 @@ fn attestation_validate_accepts_valid() {
         timestamp: 0,
         weight: DEFAULT_ATTESTATION_WEIGHT,
         attestation_data: String::from_str(&e, "x"),
+        revoked: false,
+    };
+    att.validate();
+}
+
+#[test]
+fn attestation_validate_accepts_empty_data() {
+    let e = Env::default();
+    let att = Attestation {
+        id: 0,
+        attester: soroban_sdk::Address::generate(&e),
+        subject: soroban_sdk::Address::generate(&e),
+        timestamp: 0,
+        weight: DEFAULT_ATTESTATION_WEIGHT,
+        attestation_data: String::from_str(&e, ""),
         revoked: false,
     };
     att.validate();
@@ -110,14 +129,6 @@ fn attestation_dedup_key_equality() {
         attestation_data: d,
     };
     assert_eq!(k1, k2);
-}
-
-#[test]
-#[should_panic(expected = "attestation data cannot be empty")]
-fn attestation_validate_rejects_empty_data() {
-    let e = Env::default();
-    let data = String::from_str(&e, "");
-    Attestation::validate_data(&data);
 }
 
 #[test]

--- a/contracts/credence_bond/src/types/attestation.rs
+++ b/contracts/credence_bond/src/types/attestation.rs
@@ -12,6 +12,10 @@ pub const MAX_ATTESTATION_WEIGHT: u32 = 1_000_000;
 /// Default weight when attester has no stake configured.
 pub const DEFAULT_ATTESTATION_WEIGHT: u32 = 1;
 
+/// Maximum allowed attestation data length (in bytes).
+/// Prevents unbounded storage and enforces reasonable data sizes.
+pub const MAX_ATTESTATION_DATA_LENGTH: u32 = 4096;
+
 /// Attestation record: a verifier's credibility attestation for an identity.
 ///
 /// # Fields
@@ -52,13 +56,34 @@ impl Attestation {
         }
     }
 
-    /// Validates this attestation (weight bounds). Use after deserialization or before storage.
+    /// Validates that attestation data is within allowed bounds.
+    ///
+    /// # Arguments
+    /// * `data` - The attestation data to validate
     ///
     /// # Errors
-    /// Panics if `self.weight` is zero or exceeds `MAX_ATTESTATION_WEIGHT`.
+    /// Panics if:
+    /// * `data` is empty
+    /// * `data` exceeds `MAX_ATTESTATION_DATA_LENGTH`
+    #[inline]
+    pub fn validate_data(data: &String) {
+        let len = data.len();
+        if len == 0 {
+            panic!("attestation data cannot be empty");
+        }
+        if len as u32 > MAX_ATTESTATION_DATA_LENGTH {
+            panic!("attestation data exceeds maximum length");
+        }
+    }
+
+    /// Validates this attestation (weight and data bounds). Use after deserialization or before storage.
+    ///
+    /// # Errors
+    /// Panics if weight or data are invalid.
     #[inline]
     pub fn validate(&self) {
         Self::validate_weight(self.weight);
+        Self::validate_data(&self.attestation_data);
     }
 
     /// Returns true if this attestation is currently active (not revoked).

--- a/contracts/credence_bond/src/types/attestation.rs
+++ b/contracts/credence_bond/src/types/attestation.rs
@@ -62,15 +62,10 @@ impl Attestation {
     /// * `data` - The attestation data to validate
     ///
     /// # Errors
-    /// Panics if:
-    /// * `data` is empty
-    /// * `data` exceeds `MAX_ATTESTATION_DATA_LENGTH`
+    /// Panics if `data` exceeds `MAX_ATTESTATION_DATA_LENGTH`.
     #[inline]
     pub fn validate_data(data: &String) {
         let len = data.len();
-        if len == 0 {
-            panic!("attestation data cannot be empty");
-        }
         if len as u32 > MAX_ATTESTATION_DATA_LENGTH {
             panic!("attestation data exceeds maximum length");
         }


### PR DESCRIPTION
## Description

Centralize attestation type validation and ensure all call sites reuse it; add tests for consistency.

## Requirements
- Contracts-only
- Secure, tested, documented
- 95%+ coverage, timeframe 96 hours

## Suggested execution
- Branch: `refactor/bond-attestation-validation-fresh`
- Tests: `contracts/credence_bond/src/test_attestation_types.rs`
- Test command: `cargo test -p credence_bond`

## Related to
Resolves #280