### PR TITLE
fix: ensure atomic nonce consumption by validating domain and deadlin…

### DIFF
--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -1,0 +1,48 @@
+name: Contracts Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - ci/**
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - contracts/**
+      - .github/workflows/contracts-tests.yml
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - contracts/**
+      - .github/workflows/contracts-tests.yml
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Workspace Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run workspace tests
+        run: cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -28,10 +28,20 @@ cargo build --target wasm32-unknown-unknown --release -p credence_bond
 
 ## Tests
 
+Run all workspace tests:
+
+```bash
+cargo test --workspace
+```
+
+Run specific contract tests:
+
 ```bash
 cargo test -p credence_bond
 cargo test -p credence_delegation
 ```
+
+The dedicated CI workflow at `.github/workflows/contracts-tests.yml` runs the full workspace tests on every PR.
 
 ## Linting
 

--- a/contracts/credence_bond/src/nonce.rs
+++ b/contracts/credence_bond/src/nonce.rs
@@ -11,6 +11,13 @@
 //!
 //! Domain binding ties each operation to the specific contract address,
 //! blocking cross-contract replay.
+//!
+//! The nonce validation flow is atomic: deadline and contract-domain checks are
+//! performed before the nonce is consumed, so stale or wrong-context signatures
+//! do not advance the counter.
+//!
+//! Signed actions are bound to the current contract address; this prevents the
+//! same nonce/deadline pair from replaying in a different contract context.
 
 use soroban_sdk::{Address, Env};
 
@@ -76,6 +83,9 @@ pub fn require_not_expired(e: &Env, deadline: u64) {
 /// signed payload to a specific contract address prevents cross-contract replay
 /// where a valid signature for contract A is submitted to contract B.
 ///
+/// The current contract address is compared against the caller-provided
+/// `contract_id` before the nonce is consumed.
+///
 /// # Panics
 /// Panics with "domain mismatch" if `expected_contract` does not match the
 /// current contract address.
@@ -86,12 +96,14 @@ pub fn require_domain_match(e: &Env, expected_contract: &Address) {
     }
 }
 
-/// Validate deadline (+ grace) + domain + consume nonce in one call.
+/// Validate deadline (+ grace), domain, and consume nonce in one atomic call.
 ///
-/// Order of checks:
+/// The order of checks is important:
 /// 1. Deadline — fail fast on expired signatures before touching storage.
-/// 2. Domain   — ensure the payload was signed for this contract.
+/// 2. Domain   — ensure the payload was bound to this contract address.
 /// 3. Nonce    — prevent replay and enforce ordering.
+///
+/// If either deadline or domain validation fails, the nonce is not consumed.
 pub fn validate_and_consume(
     e: &Env,
     identity: &Address,

--- a/contracts/credence_bond/src/test_replay_prevention.rs
+++ b/contracts/credence_bond/src/test_replay_prevention.rs
@@ -4,6 +4,7 @@
 use crate::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Env, String};
+use std::panic::AssertUnwindSafe;
 
 fn setup(
     e: &Env,
@@ -122,6 +123,62 @@ fn expired_deadline_rejected_on_add_attestation() {
 }
 
 #[test]
+fn expired_deadline_does_not_consume_nonce_on_add_attestation() {
+    let e = Env::default();
+    let (client, attester, contract_id) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let deadline = 1000u64;
+    e.ledger().with_mut(|l| l.timestamp = 2000);
+
+    let initial_nonce = client.get_nonce(&attester);
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        client.add_attestation(
+            &attester,
+            &subject,
+            &String::from_str(&e, "late"),
+            &contract_id,
+            &deadline,
+            &initial_nonce,
+        );
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(client.get_nonce(&attester), initial_nonce);
+}
+
+#[test]
+fn wrong_contract_does_not_consume_nonce_on_revoke() {
+    let e = Env::default();
+    let (client, attester, contract_id) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let deadline = e.ledger().timestamp() + 5000;
+
+    let att = client.add_attestation(
+        &attester,
+        &subject,
+        &String::from_str(&e, "r"),
+        &contract_id,
+        &deadline,
+        &0u64,
+    );
+    let nonce_before = client.get_nonce(&attester);
+    let wrong_contract = soroban_sdk::Address::generate(&e);
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        client.revoke_attestation(
+            &attester,
+            &att.id,
+            &wrong_contract,
+            &deadline,
+            &nonce_before,
+        );
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(client.get_nonce(&attester), nonce_before);
+}
+
+#[test]
 #[should_panic(expected = "signature expired")]
 fn expired_deadline_rejected_on_revoke() {
     let e = Env::default();
@@ -183,6 +240,30 @@ fn wrong_contract_address_rejected_on_add_attestation() {
         &deadline,
         &0u64,
     );
+}
+
+#[test]
+fn wrong_contract_does_not_consume_nonce_on_add_attestation() {
+    let e = Env::default();
+    let (client, attester, _contract_id) = setup(&e);
+    let subject = soroban_sdk::Address::generate(&e);
+    let deadline = e.ledger().timestamp() + 1000;
+    let initial_nonce = client.get_nonce(&attester);
+    let wrong_contract = soroban_sdk::Address::generate(&e);
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        client.add_attestation(
+            &attester,
+            &subject,
+            &String::from_str(&e, "cross"),
+            &wrong_contract,
+            &deadline,
+            &initial_nonce,
+        );
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(client.get_nonce(&attester), initial_nonce);
 }
 
 #[test]

--- a/docs/attestations.md
+++ b/docs/attestations.md
@@ -19,7 +19,9 @@ Verifiers add credibility attestations to identity bonds. Only authorized attest
 - **add_attestation(attester, subject, attestation_data, nonce)**  
   - Caller must be the attester (require_auth).  
   - Attester must be registered.  
+  - `contract_id` and `deadline` are part of the signed action context and are validated before nonce consumption.  
   - Nonce must match current attester nonce (replay prevention); nonce is incremented on success.  
+  - Signed actions are domain-bound to the contract address to prevent replay across unrelated contract contexts.  
   - Duplicate (same verifier, identity, attestation_data) is rejected.  
   - Weight is computed from attester stake (see weighted attestations).  
   - Emits `attestation_added` with (subject, id, attester, attestation_data, weight).

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,6 +11,9 @@ Security mechanisms for the Credence bond and attestation system.
 ## Replay attack prevention
 
 - **Nonces** — Each identity has a nonce (starts at 0). State-changing attestation calls require the current nonce and increment it on success.
+- **Atomic validation** — Deadlines and contract-domain checks are validated before the nonce is consumed, so failed or expired signed actions do not advance the nonce.
+- **Contract-domain binding** — `contract_id` is validated against the current contract address, preventing the same nonce/deadline pair from replaying across different contract deployments.
+- **Signed-action context** — `contract_id`, `deadline`, and `nonce` are all bound to the current contract context before consuming the nonce.
 - **get_nonce(identity)** — Returns the current nonce; the caller must pass this value in the next add_attestation or revoke_attestation call.
 - Replayed or out-of-order transactions are rejected with "invalid nonce" because the stored nonce no longer matches.
 - Nonce overflow is handled by checked arithmetic (panic if increment would overflow).


### PR DESCRIPTION
…e before increment, and add CI workflow for contract tests. CLOSES #265 
CLOSES #265 [Fresh 2026-04][Contracts] CI: contracts workspace tests workflow (cargo test --workspace) + caching 