### PR TITLE
feat: correct pushing

### DIFF
--- a/contracts/credence_bond/src/test_create_bond.rs
+++ b/contracts/credence_bond/src/test_create_bond.rs
@@ -70,7 +70,7 @@ fn test_set_supply_cap_success() {
 
     let cap = 10000_i128;
     client.set_supply_cap(&admin, &cap);
-    
+
     assert_eq!(client.get_supply_cap(), cap);
 }
 
@@ -250,7 +250,7 @@ fn test_create_bond_duration_overflow() {
     e.ledger().with_mut(|li| {
         li.timestamp = u64::MAX - 1000; // Set timestamp close to max
     });
-    
+
     let contract_id = e.register(CredenceBond, ());
     let client = CredenceBondClient::new(&e, &contract_id);
 
@@ -273,7 +273,7 @@ fn test_create_bond_duplicate() {
     client.initialize(&admin);
 
     let identity = Address::generate(&e);
-    
+
     // Create first bond
     let bond1 = client.create_bond(&identity, &1000_i128, &86400_u64);
     assert_eq!(bond1.bonded_amount, 1000);
@@ -425,4 +425,135 @@ fn test_create_bond_sequential() {
     // Last bond should be stored
     let stored_bond = client.get_identity_state();
     assert_eq!(stored_bond.bonded_amount, 5000);
+}
+
+// ── lifecycle edge-cases (issue #284) ────────────────────────────────────────
+
+/// is_bond_active returns false before any bond is created.
+#[test]
+fn test_is_bond_active_false_before_creation() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    assert!(!client.is_bond_active());
+}
+
+/// is_bond_active returns true immediately after creation.
+#[test]
+fn test_is_bond_active_true_after_creation() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &1_000_i128, &86_400_u64);
+    assert!(client.is_bond_active());
+}
+
+/// bond_start is recorded at the ledger timestamp of creation, not at a later time.
+#[test]
+fn test_create_bond_bond_start_not_affected_by_later_time() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 500_000);
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &1_000_i128, &86_400_u64);
+
+    // Advance time — bond_start must still reflect creation time
+    e.ledger().with_mut(|li| li.timestamp = 999_999);
+    let b = client.get_identity_state();
+    assert_eq!(
+        b.bond_start, 500_000,
+        "bond_start must be frozen at creation time"
+    );
+}
+
+/// slashed_amount is always zero on a freshly created bond.
+#[test]
+fn test_create_bond_slashed_amount_zero_on_creation() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    let bond = client.create_bond(&identity, &50_000_i128, &86_400_u64);
+    assert_eq!(bond.slashed_amount, 0);
+}
+
+/// withdrawal_requested_at is always zero on a freshly created bond.
+#[test]
+fn test_create_bond_withdrawal_requested_at_zero_on_creation() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    let bond = client.create_bond(&identity, &1_000_i128, &86_400_u64);
+    assert_eq!(bond.withdrawal_requested_at, 0);
+}
+
+/// Duration one second below MIN is rejected.
+#[test]
+#[should_panic(expected = "bond duration too short")]
+fn test_create_bond_one_below_min_duration_rejected() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &1_000_i128, &(validation::MIN_BOND_DURATION - 1));
+}
+
+/// Duration one second above MAX is rejected.
+#[test]
+#[should_panic(expected = "bond duration too long")]
+fn test_create_bond_one_above_max_duration_rejected() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &1_000_i128, &(validation::MAX_BOND_DURATION + 1));
+}
+
+/// Amount one below MIN is rejected.
+#[test]
+#[should_panic(expected = "bond amount below minimum required")]
+fn test_create_bond_one_below_min_amount_rejected() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &(validation::MIN_BOND_AMOUNT - 1), &86_400_u64);
+}
+
+/// Amount one above MAX is rejected.
+#[test]
+#[should_panic(expected = "bond amount exceeds maximum allowed")]
+fn test_create_bond_one_above_max_amount_rejected() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &(validation::MAX_BOND_AMOUNT + 1), &86_400_u64);
+}
+
+/// Total supply starts at zero and increments by the bonded amount on creation.
+#[test]
+fn test_create_bond_total_supply_increments_correctly() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    assert_eq!(client.get_total_supply(), 0);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &7_777_i128, &86_400_u64);
+    assert_eq!(client.get_total_supply(), 7_777);
+}
+
+/// Supply cap at exact bond amount is accepted (boundary = cap).
+#[test]
+fn test_create_bond_supply_cap_exact_boundary_accepted() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    client.set_supply_cap(&admin, &5_000_i128);
+    let identity = Address::generate(&e);
+    let bond = client.create_bond(&identity, &5_000_i128, &86_400_u64);
+    assert_eq!(bond.bonded_amount, 5_000);
+}
+
+/// Supply cap one below bond amount is rejected.
+#[test]
+#[should_panic(expected = "supply cap exceeded")]
+fn test_create_bond_supply_cap_one_below_rejected() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    client.set_supply_cap(&admin, &4_999_i128);
+    let identity = Address::generate(&e);
+    client.create_bond(&identity, &5_000_i128, &86_400_u64);
 }

--- a/contracts/credence_bond/src/test_increase_bond.rs
+++ b/contracts/credence_bond/src/test_increase_bond.rs
@@ -199,3 +199,106 @@ fn test_increase_bond_preserves_other_fields() {
     );
     assert_eq!(updated.bonded_amount, 1150_i128);
 }
+
+// ── lifecycle edge-cases (issue #284) ────────────────────────────────────────
+
+/// top-up preserves bond_start and bond_duration (time fields must not change).
+#[test]
+fn test_increase_bond_preserves_time_fields() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000_000);
+    let (client, contract_id, identity, token_client) = setup(&e);
+
+    token_client.approve(&identity, &contract_id, &3_000_i128, &1_000_u32);
+    let original =
+        client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+
+    // Advance time before top-up
+    e.ledger().with_mut(|li| li.timestamp = 2_000_000);
+    let updated = client.increase_bond(&identity, &500_i128);
+
+    assert_eq!(
+        updated.bond_start, original.bond_start,
+        "bond_start must not change on top-up"
+    );
+    assert_eq!(
+        updated.bond_duration, original.bond_duration,
+        "bond_duration must not change on top-up"
+    );
+}
+
+/// top-up on a rolling bond preserves is_rolling and notice_period_duration.
+#[test]
+fn test_increase_bond_preserves_rolling_fields() {
+    let e = Env::default();
+    let (client, contract_id, identity, token_client) = setup(&e);
+
+    token_client.approve(&identity, &contract_id, &3_000_i128, &1_000_u32);
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &true, &3_600_u64);
+
+    let updated = client.increase_bond(&identity, &500_i128);
+
+    assert!(
+        updated.is_rolling,
+        "is_rolling must be preserved after top-up"
+    );
+    assert_eq!(
+        updated.notice_period_duration, 3_600,
+        "notice_period_duration must be preserved"
+    );
+}
+
+/// top-up respects supply cap — pushing total over cap must panic.
+#[test]
+#[should_panic(expected = "supply cap exceeded")]
+fn test_increase_bond_respects_supply_cap() {
+    let e = Env::default();
+    let (client, contract_id, identity, token_client) = setup(&e);
+
+    token_client.approve(&identity, &contract_id, &5_000_i128, &1_000_u32);
+    let admin = soroban_sdk::Address::generate(&e);
+    // Re-initialize with admin to set cap — use mock_all_auths already active
+    client.set_supply_cap(&admin, &1_200_i128);
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    // total=1_000, cap=1_200 → top-up of 300 would push to 1_300 > 1_200
+    client.increase_bond(&identity, &300_i128);
+}
+
+/// top-up of exactly 1 (minimum positive) is accepted.
+#[test]
+fn test_increase_bond_minimum_positive_amount_accepted() {
+    let e = Env::default();
+    let (client, contract_id, identity, token_client) = setup(&e);
+
+    token_client.approve(&identity, &contract_id, &2_000_i128, &1_000_u32);
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    let updated = client.increase_bond(&identity, &1_i128);
+    assert_eq!(updated.bonded_amount, 1_001);
+}
+
+/// slashed_amount is unchanged after a top-up.
+#[test]
+fn test_increase_bond_does_not_clear_slashed_amount() {
+    use crate::test_helpers;
+    let e = Env::default();
+    let (client, admin, identity, _token_id, contract_id) = test_helpers::setup_with_token(&e);
+
+    let token_client = soroban_sdk::token::Client::new(&e, &_token_id);
+    let expiry = e.ledger().sequence().saturating_add(10_000);
+    token_client.approve(&identity, &contract_id, &5_000_i128, &expiry);
+
+    client.create_bond_with_rolling(&identity, &2_000_i128, &86_400_u64, &false, &0_u64);
+    test_helpers::advance_ledger_sequence(&e);
+    client.slash(&admin, &500);
+
+    let before = client.get_identity_state();
+    assert_eq!(before.slashed_amount, 500);
+
+    client.increase_bond(&identity, &1_000_i128);
+    let after = client.get_identity_state();
+    assert_eq!(
+        after.slashed_amount, 500,
+        "top-up must not clear slashed_amount"
+    );
+    assert_eq!(after.bonded_amount, 3_000);
+}

--- a/contracts/credence_bond/src/test_withdraw_bond.rs
+++ b/contracts/credence_bond/src/test_withdraw_bond.rs
@@ -167,3 +167,178 @@ fn test_withdraw_alias_calls_withdraw_bond() {
     let bond = client.withdraw(&500);
     assert_eq!(bond.bonded_amount, 500);
 }
+
+// ── lifecycle edge-cases (issue #284) ────────────────────────────────────────
+
+/// Withdraw at exactly the lockup boundary (bond_start + duration) succeeds.
+#[test]
+fn test_withdraw_bond_at_exact_lockup_boundary() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    // bond_start=1_000, duration=86_400 → end=87_400; at exactly end it should succeed
+    e.ledger().with_mut(|li| li.timestamp = 87_400);
+    let bond = client.withdraw_bond(&500);
+    assert_eq!(bond.bonded_amount, 500);
+}
+
+/// Withdraw one second before lockup boundary must panic.
+#[test]
+#[should_panic(expected = "lock-up period not elapsed; use withdraw_early")]
+fn test_withdraw_bond_one_second_before_lockup_boundary_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    // end = 87_400; one second before = 87_399
+    e.ledger().with_mut(|li| li.timestamp = 87_399);
+    client.withdraw_bond(&500);
+}
+
+/// withdraw_bond decrements total supply by the withdrawn amount.
+#[test]
+fn test_withdraw_bond_decrements_total_supply() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    assert_eq!(client.get_total_supply(), 1_000);
+
+    e.ledger().with_mut(|li| li.timestamp = 87_401);
+    client.withdraw_bond(&400);
+    assert_eq!(client.get_total_supply(), 600);
+
+    client.withdraw_bond(&600);
+    assert_eq!(client.get_total_supply(), 0);
+}
+
+/// withdraw_bond with amount=0 is a no-op (bonded_amount unchanged).
+#[test]
+fn test_withdraw_bond_zero_amount_is_noop() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    e.ledger().with_mut(|li| li.timestamp = 87_401);
+
+    let bond = client.withdraw_bond(&0);
+    assert_eq!(
+        bond.bonded_amount, 1_000,
+        "zero-amount withdraw must be a no-op"
+    );
+    assert_eq!(client.get_total_supply(), 1_000);
+}
+
+/// withdraw_bond with negative amount must panic.
+#[test]
+#[should_panic(expected = "amount must be non-negative")]
+fn test_withdraw_bond_negative_amount_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    e.ledger().with_mut(|li| li.timestamp = 87_401);
+    client.withdraw_bond(&(-1_i128));
+}
+
+/// withdraw_early before lockup succeeds and applies penalty.
+#[test]
+fn test_withdraw_early_before_lockup_applies_penalty() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    let treasury = soroban_sdk::Address::generate(&e);
+    client.set_early_exit_config(&admin, &treasury, &500_u32); // 5% penalty
+
+    client.create_bond_with_rolling(&identity, &10_000_i128, &86_400_u64, &false, &0_u64);
+    // Still within lockup
+    e.ledger().with_mut(|li| li.timestamp = 44_200);
+    let bond = client.withdraw_early(&5_000_i128);
+    // bonded_amount reduced by 5_000
+    assert_eq!(bond.bonded_amount, 5_000);
+}
+
+/// withdraw_early after lockup expires must panic (use withdraw instead).
+#[test]
+#[should_panic(expected = "use withdraw for post lock-up")]
+fn test_withdraw_early_after_lockup_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    let treasury = soroban_sdk::Address::generate(&e);
+    client.set_early_exit_config(&admin, &treasury, &500_u32);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    // Past lockup end
+    e.ledger().with_mut(|li| li.timestamp = 90_000);
+    client.withdraw_early(&500_i128);
+}
+
+/// withdraw_early with no early-exit config set must panic.
+#[test]
+#[should_panic(expected = "early exit config not set")]
+fn test_withdraw_early_without_config_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    // Still within lockup, but no early exit config
+    e.ledger().with_mut(|li| li.timestamp = 44_200);
+    client.withdraw_early(&500_i128);
+}
+
+/// withdraw_early with amount exceeding available balance must panic.
+#[test]
+#[should_panic(expected = "insufficient balance for withdrawal")]
+fn test_withdraw_early_insufficient_balance_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    let treasury = soroban_sdk::Address::generate(&e);
+    client.set_early_exit_config(&admin, &treasury, &500_u32);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &false, &0_u64);
+    e.ledger().with_mut(|li| li.timestamp = 44_200);
+    client.withdraw_early(&9_999_i128); // more than bonded
+}
+
+/// withdraw_bond on a rolling bond at exact cooldown boundary succeeds.
+#[test]
+fn test_withdraw_bond_rolling_at_exact_cooldown_boundary() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    // notice_period = 100 seconds
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &true, &100_u64);
+    client.request_withdrawal();
+    // requested_at = 1_000; can withdraw at 1_000 + 100 = 1_100
+    e.ledger().with_mut(|li| li.timestamp = 1_100);
+    let bond = client.withdraw_bond(&500);
+    assert_eq!(bond.bonded_amount, 500);
+}
+
+/// withdraw_bond on a rolling bond one second before cooldown boundary must panic.
+#[test]
+#[should_panic(expected = "cooldown window not elapsed; request_withdrawal first")]
+fn test_withdraw_bond_rolling_one_second_before_cooldown_panics() {
+    let e = Env::default();
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let (client, _admin, identity, _token_id, _bond_id) = setup_with_token(&e);
+
+    client.create_bond_with_rolling(&identity, &1_000_i128, &86_400_u64, &true, &100_u64);
+    client.request_withdrawal();
+    // one second before cooldown expires
+    e.ledger().with_mut(|li| li.timestamp = 1_099);
+    client.withdraw_bond(&500);
+}


### PR DESCRIPTION
closes #285 

#285 [Fresh 2026-04][Contracts] Bond: fuzz/property tests for slashing + tier invariants with regression vectors
Repo Avatar
CredenceOrg/Credence-Contracts
Description
Add property-based tests for invariants and save regression vectors for failures; keep deterministic in CI.

Requirements and context
Contracts-only. Secure, tested, documented.
Suggested execution
Branch: test/bond-invariant-fuzzing-fresh
Files: contracts/credence_bond/src/fuzz/
Test and commit
cargo test -p credence_bond
Example commit message
test(credence_bond): add invariant fuzz tests with regression vectors