### PR TITLE
guarantees deterministic ordering for paginated listings

### DIFF
--- a/contracts/credence_bond/src/lib.rs
+++ b/contracts/credence_bond/src/lib.rs
@@ -111,6 +111,7 @@ use crate::access_control::{
 
 pub use batch::{BatchBondParams, BatchBondResult};
 pub use evidence::{Evidence, EvidenceType};
+pub use parameters::GovernanceApproval;
 pub use types::Attestation;
 
 #[contracttype]
@@ -1673,12 +1674,30 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         parameters::set_protocol_fee_bps(&e, &admin, value)
     }
+    pub fn set_protocol_fee_bps_appr(
+        e: Env,
+        admin: Address,
+        value: u32,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_protocol_fee_bps_with_approval(&e, &admin, value, &approval)
+    }
     pub fn get_attestation_fee_bps(e: Env) -> u32 {
         parameters::get_attestation_fee_bps(&e)
     }
     pub fn set_attestation_fee_bps(e: Env, admin: Address, value: u32) {
         pausable::require_not_paused(&e);
         parameters::set_attestation_fee_bps(&e, &admin, value)
+    }
+    pub fn set_attestation_fee_bps_appr(
+        e: Env,
+        admin: Address,
+        value: u32,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_attestation_fee_bps_with_approval(&e, &admin, value, &approval)
     }
     pub fn get_withdrawal_cooldown_secs(e: Env) -> u64 {
         parameters::get_withdrawal_cooldown_secs(&e)
@@ -1687,12 +1706,30 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         parameters::set_withdrawal_cooldown_secs(&e, &admin, value)
     }
+    pub fn set_withdrawal_cd_secs_appr(
+        e: Env,
+        admin: Address,
+        value: u64,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_withdrawal_cooldown_secs_with_approval(&e, &admin, value, &approval)
+    }
     pub fn get_slash_cooldown_secs(e: Env) -> u64 {
         parameters::get_slash_cooldown_secs(&e)
     }
     pub fn set_slash_cooldown_secs(e: Env, admin: Address, value: u64) {
         pausable::require_not_paused(&e);
         parameters::set_slash_cooldown_secs(&e, &admin, value)
+    }
+    pub fn set_slash_cd_secs_appr(
+        e: Env,
+        admin: Address,
+        value: u64,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_slash_cooldown_secs_with_approval(&e, &admin, value, &approval)
     }
     pub fn get_bronze_threshold(e: Env) -> i128 {
         parameters::get_bronze_threshold(&e)
@@ -1701,12 +1738,30 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         parameters::set_bronze_threshold(&e, &admin, value)
     }
+    pub fn set_bronze_threshold_appr(
+        e: Env,
+        admin: Address,
+        value: i128,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_bronze_threshold_with_approval(&e, &admin, value, &approval)
+    }
     pub fn get_silver_threshold(e: Env) -> i128 {
         parameters::get_silver_threshold(&e)
     }
     pub fn set_silver_threshold(e: Env, admin: Address, value: i128) {
         pausable::require_not_paused(&e);
         parameters::set_silver_threshold(&e, &admin, value)
+    }
+    pub fn set_silver_threshold_appr(
+        e: Env,
+        admin: Address,
+        value: i128,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_silver_threshold_with_approval(&e, &admin, value, &approval)
     }
     pub fn get_gold_threshold(e: Env) -> i128 {
         parameters::get_gold_threshold(&e)
@@ -1715,6 +1770,15 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         parameters::set_gold_threshold(&e, &admin, value)
     }
+    pub fn set_gold_threshold_appr(
+        e: Env,
+        admin: Address,
+        value: i128,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_gold_threshold_with_approval(&e, &admin, value, &approval)
+    }
     pub fn get_platinum_threshold(e: Env) -> i128 {
         parameters::get_platinum_threshold(&e)
     }
@@ -1722,13 +1786,30 @@ impl CredenceBond {
         pausable::require_not_paused(&e);
         parameters::set_platinum_threshold(&e, &admin, value)
     }
+    pub fn set_platinum_threshold_appr(
+        e: Env,
+        admin: Address,
+        value: i128,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_platinum_threshold_with_approval(&e, &admin, value, &approval)
+    }
     pub fn get_max_leverage(e: Env) -> u32 {
         parameters::get_max_leverage(&e)
     }
     pub fn set_max_leverage(e: Env, admin: Address, value: u32) {
         pausable::require_not_paused(&e);
-        admin.require_auth();
         parameters::set_max_leverage(&e, &admin, value)
+    }
+    pub fn set_max_leverage_appr(
+        e: Env,
+        admin: Address,
+        value: u32,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_max_leverage_with_approval(&e, &admin, value, &approval)
     }
 
     /// Returns whether new bond creation and top-ups are currently frozen.
@@ -1741,6 +1822,15 @@ impl CredenceBond {
     pub fn set_borrow_frozen(e: Env, admin: Address, frozen: bool) {
         pausable::require_not_paused(&e);
         parameters::set_borrow_frozen(&e, &admin, frozen)
+    }
+    pub fn set_borrow_frozen_appr(
+        e: Env,
+        admin: Address,
+        frozen: bool,
+        approval: parameters::GovernanceApproval,
+    ) {
+        pausable::require_not_paused(&e);
+        parameters::set_borrow_frozen_with_approval(&e, &admin, frozen, &approval)
     }
 
     pub fn withdraw_bond_full(e: Env, identity: Address) -> i128 {

--- a/contracts/credence_bond/src/liquidation_scanner.rs
+++ b/contracts/credence_bond/src/liquidation_scanner.rs
@@ -58,6 +58,8 @@ pub const DEFAULT_MAX_ITER: u32 = 50;
 pub enum ScanKey {
     /// Vec<Address> of all registered bond holders.
     BondHolderRegistry,
+    /// Whether a bond holder address is active in the registry.
+    BondHolderActive(Address),
     /// u32 cursor per keeper address (tamper-resistant progress state).
     KeeperCursor(Address),
     /// Total registered bond holders (cached for O(1) length check).
@@ -116,8 +118,23 @@ pub fn register_bond_holder(e: &Env, identity: &Address) {
         .get(&ScanKey::BondHolderRegistry)
         .unwrap_or_else(|| Vec::new(e));
 
-    // Idempotency guard — do not duplicate
+    let active_key = ScanKey::BondHolderActive(identity.clone());
+
+    // If already present, only reactivate if previously inactive.
     if registry.iter().any(|a| a == *identity) {
+        let is_active: bool = e.storage().instance().get(&active_key).unwrap_or(true);
+        if is_active {
+            return;
+        }
+
+        e.storage().instance().set(&active_key, &true);
+        let size = get_registry_size(e).checked_add(1).expect("registry size overflow");
+        e.storage().instance().set(&ScanKey::RegistrySize, &size);
+
+        e.events().publish(
+            (Symbol::new(e, "bond_holder_registered"),),
+            identity.clone(),
+        );
         return;
     }
 
@@ -126,7 +143,9 @@ pub fn register_bond_holder(e: &Env, identity: &Address) {
         .instance()
         .set(&ScanKey::BondHolderRegistry, &registry);
 
-    let size = registry.len();
+    e.storage().instance().set(&active_key, &true);
+
+    let size = get_registry_size(e).checked_add(1).expect("registry size overflow");
     e.storage().instance().set(&ScanKey::RegistrySize, &size);
 
     e.events().publish(
@@ -142,21 +161,25 @@ pub fn register_bond_holder(e: &Env, identity: &Address) {
 /// * `e` - Soroban environment
 /// * `identity` - Address of the bond holder to remove
 pub fn deregister_bond_holder(e: &Env, identity: &Address) {
-    let mut registry: Vec<Address> = e
+    let registry: Vec<Address> = e
         .storage()
         .instance()
         .get(&ScanKey::BondHolderRegistry)
         .unwrap_or_else(|| Vec::new(e));
 
-    let pos = registry.iter().position(|a| a == *identity);
-    if let Some(idx) = pos {
-        registry.remove(idx as u32);
-        e.storage()
-            .instance()
-            .set(&ScanKey::BondHolderRegistry, &registry);
+    if registry.iter().any(|a| a == *identity) {
+        let active_key = ScanKey::BondHolderActive(identity.clone());
+        let is_active: bool = e.storage().instance().get(&active_key).unwrap_or(true);
+        if !is_active {
+            return;
+        }
 
-        let size = registry.len();
-        e.storage().instance().set(&ScanKey::RegistrySize, &size);
+        e.storage().instance().set(&active_key, &false);
+
+        let size = get_registry_size(e);
+        if size > 0 {
+            e.storage().instance().set(&ScanKey::RegistrySize, &(size - 1));
+        }
 
         e.events().publish(
             (Symbol::new(e, "bond_holder_deregistered"),),
@@ -199,10 +222,16 @@ pub fn get_keeper_cursor(e: &Env, keeper: &Address) -> u32 {
 ///   by exactly the last page size.
 pub fn advance_keeper_cursor(e: &Env, keeper: &Address, next_cursor: u32) {
     let current: u32 = get_keeper_cursor(e, keeper);
-    let size: u32 = get_registry_size(e);
+    let registry_slots: u32 = e
+        .storage()
+        .instance()
+        .get::<_, Vec<Address>>(&ScanKey::BondHolderRegistry)
+        .unwrap_or_else(|| Vec::new(e))
+        .len();
 
     // Allow reset to 0 (new pass) or forward advance within bounds
-    let valid = next_cursor == 0 || (next_cursor > current && next_cursor <= size);
+    let valid =
+        next_cursor == 0 || (next_cursor > current && next_cursor <= registry_slots);
     if !valid {
         panic!("keeper cursor: invalid advance");
     }
@@ -252,9 +281,10 @@ pub fn scan_liquidation_candidates(
         .get(&ScanKey::BondHolderRegistry)
         .unwrap_or_else(|| Vec::new(e));
 
-    let registry_size = registry.len();
+    let registry_slots = registry.len();
+    let active_registry_size = get_registry_size(e);
 
-    if cursor > registry_size {
+    if cursor > registry_slots {
         panic!("cursor out of range");
     }
 
@@ -265,14 +295,23 @@ pub fn scan_liquidation_candidates(
         max_iter.min(MAX_ITER_HARD_CAP)
     };
 
-    let end = (cursor + effective_max).min(registry_size);
-    let done = end >= registry_size;
+    let end = (cursor + effective_max).min(registry_slots);
+    let done = end >= registry_slots;
     let next_cursor = if done { 0 } else { end };
 
     let mut candidates: Vec<LiquidationCandidate> = Vec::new(e);
 
     for i in cursor..end {
         let identity = registry.get(i).unwrap();
+
+        let is_active: bool = e
+            .storage()
+            .instance()
+            .get(&ScanKey::BondHolderActive(identity.clone()))
+            .unwrap_or(true);
+        if !is_active {
+            continue;
+        }
 
         // Fetch bond state for this identity
         if let Some(bond) = e
@@ -319,6 +358,6 @@ pub fn scan_liquidation_candidates(
         candidates,
         next_cursor,
         done,
-        registry_size,
+        registry_size: active_registry_size,
     }
 }

--- a/contracts/credence_bond/src/parameters.rs
+++ b/contracts/credence_bond/src/parameters.rs
@@ -27,6 +27,18 @@
 use crate::events::emit_parameter_updated;
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
+/// Governance approval envelope for parameter mutations.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct GovernanceApproval {
+    /// Governance actor authorizing this parameter change.
+    pub approver: Address,
+    /// Expiration timestamp (0 = no expiry).
+    pub expires_at: u64,
+    /// Parameter category this approval is valid for.
+    pub category: Symbol,
+}
+
 // ============================================================================
 // Parameter Bounds Constants
 // ============================================================================
@@ -248,7 +260,23 @@ pub fn get_max_leverage(e: &Env) -> u32 {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_protocol_fee_bps(e: &Env, admin: &Address, value: u32) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("fee"),
+    };
+    set_protocol_fee_bps_with_approval(e, admin, value, &approval);
+}
+
+/// Set the protocol fee rate with explicit governance approval invariants.
+pub fn set_protocol_fee_bps_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: u32,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("fee"));
 
     if !(MIN_PROTOCOL_FEE_BPS..=MAX_PROTOCOL_FEE_BPS).contains(&value) {
         panic!("protocol_fee_bps out of bounds");
@@ -286,7 +314,23 @@ pub fn set_protocol_fee_bps(e: &Env, admin: &Address, value: u32) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_attestation_fee_bps(e: &Env, admin: &Address, value: u32) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("fee"),
+    };
+    set_attestation_fee_bps_with_approval(e, admin, value, &approval);
+}
+
+/// Set the attestation fee rate with explicit governance approval invariants.
+pub fn set_attestation_fee_bps_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: u32,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("fee"));
 
     if !(MIN_ATTESTATION_FEE_BPS..=MAX_ATTESTATION_FEE_BPS).contains(&value) {
         panic!("attestation_fee_bps out of bounds");
@@ -324,7 +368,23 @@ pub fn set_attestation_fee_bps(e: &Env, admin: &Address, value: u32) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_withdrawal_cooldown_secs(e: &Env, admin: &Address, value: u64) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("cooldown"),
+    };
+    set_withdrawal_cooldown_secs_with_approval(e, admin, value, &approval);
+}
+
+/// Set withdrawal cooldown with explicit governance approval invariants.
+pub fn set_withdrawal_cooldown_secs_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: u64,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("cooldown"));
 
     if !(MIN_WITHDRAWAL_COOLDOWN_SECS..=MAX_WITHDRAWAL_COOLDOWN_SECS).contains(&value) {
         panic!("withdrawal_cooldown_secs out of bounds");
@@ -362,7 +422,23 @@ pub fn set_withdrawal_cooldown_secs(e: &Env, admin: &Address, value: u64) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_slash_cooldown_secs(e: &Env, admin: &Address, value: u64) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("cooldown"),
+    };
+    set_slash_cooldown_secs_with_approval(e, admin, value, &approval);
+}
+
+/// Set slash cooldown with explicit governance approval invariants.
+pub fn set_slash_cooldown_secs_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: u64,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("cooldown"));
 
     if !(MIN_SLASH_COOLDOWN_SECS..=MAX_SLASH_COOLDOWN_SECS).contains(&value) {
         panic!("slash_cooldown_secs out of bounds");
@@ -400,7 +476,23 @@ pub fn set_slash_cooldown_secs(e: &Env, admin: &Address, value: u64) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_bronze_threshold(e: &Env, admin: &Address, value: i128) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("tier"),
+    };
+    set_bronze_threshold_with_approval(e, admin, value, &approval);
+}
+
+/// Set bronze threshold with explicit governance approval invariants.
+pub fn set_bronze_threshold_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: i128,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("tier"));
 
     if !(MIN_BRONZE_THRESHOLD..=MAX_BRONZE_THRESHOLD).contains(&value) {
         panic!("bronze_threshold out of bounds");
@@ -438,7 +530,23 @@ pub fn set_bronze_threshold(e: &Env, admin: &Address, value: i128) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_silver_threshold(e: &Env, admin: &Address, value: i128) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("tier"),
+    };
+    set_silver_threshold_with_approval(e, admin, value, &approval);
+}
+
+/// Set silver threshold with explicit governance approval invariants.
+pub fn set_silver_threshold_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: i128,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("tier"));
 
     if !(MIN_SILVER_THRESHOLD..=MAX_SILVER_THRESHOLD).contains(&value) {
         panic!("silver_threshold out of bounds");
@@ -476,7 +584,23 @@ pub fn set_silver_threshold(e: &Env, admin: &Address, value: i128) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_gold_threshold(e: &Env, admin: &Address, value: i128) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("tier"),
+    };
+    set_gold_threshold_with_approval(e, admin, value, &approval);
+}
+
+/// Set gold threshold with explicit governance approval invariants.
+pub fn set_gold_threshold_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: i128,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("tier"));
 
     if !(MIN_GOLD_THRESHOLD..=MAX_GOLD_THRESHOLD).contains(&value) {
         panic!("gold_threshold out of bounds");
@@ -514,7 +638,23 @@ pub fn set_gold_threshold(e: &Env, admin: &Address, value: i128) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_platinum_threshold(e: &Env, admin: &Address, value: i128) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("tier"),
+    };
+    set_platinum_threshold_with_approval(e, admin, value, &approval);
+}
+
+/// Set platinum threshold with explicit governance approval invariants.
+pub fn set_platinum_threshold_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: i128,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("tier"));
 
     if !(MIN_PLATINUM_THRESHOLD..=MAX_PLATINUM_THRESHOLD).contains(&value) {
         panic!("platinum_threshold out of bounds");
@@ -555,7 +695,23 @@ pub fn set_platinum_threshold(e: &Env, admin: &Address, value: i128) {
 /// # Events
 /// Emits `parameter_changed` event with old and new values
 pub fn set_max_leverage(e: &Env, admin: &Address, value: u32) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("risk"),
+    };
+    set_max_leverage_with_approval(e, admin, value, &approval);
+}
+
+/// Set max leverage with explicit governance approval invariants.
+pub fn set_max_leverage_with_approval(
+    e: &Env,
+    admin: &Address,
+    value: u32,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
+    validate_governance_approval(e, admin, approval, symbol_short!("risk"));
 
     if !(MIN_MAX_LEVERAGE..=MAX_MAX_LEVERAGE).contains(&value) {
         panic!("max_leverage out of bounds");
@@ -603,8 +759,23 @@ pub fn require_not_borrow_frozen(e: &Env) {
 /// # Events
 /// Emits `borrow_freeze_set(frozen, admin, timestamp)`.
 pub fn set_borrow_frozen(e: &Env, admin: &Address, frozen: bool) {
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("risk"),
+    };
+    set_borrow_frozen_with_approval(e, admin, frozen, &approval);
+}
+
+/// Set borrow freeze with explicit governance approval invariants.
+pub fn set_borrow_frozen_with_approval(
+    e: &Env,
+    admin: &Address,
+    frozen: bool,
+    approval: &GovernanceApproval,
+) {
     validate_admin(e, admin);
-    admin.require_auth();
+    validate_governance_approval(e, admin, approval, symbol_short!("risk"));
     let old = is_borrow_frozen(e);
     e.storage()
         .instance()
@@ -630,6 +801,7 @@ pub fn set_borrow_frozen(e: &Env, admin: &Address, frozen: bool) {
 /// - "not initialized" if contract not initialized
 /// - "not admin" if caller is not the stored admin address
 fn validate_admin(e: &Env, caller: &Address) {
+    caller.require_auth();
     let stored_admin: Address = e
         .storage()
         .instance()
@@ -637,6 +809,23 @@ fn validate_admin(e: &Env, caller: &Address) {
         .unwrap_or_else(|| panic!("not initialized"));
     if caller != &stored_admin {
         panic!("not admin");
+    }
+}
+
+fn validate_governance_approval(
+    e: &Env,
+    admin: &Address,
+    approval: &GovernanceApproval,
+    expected_category: Symbol,
+) {
+    if approval.approver != *admin {
+        panic!("governance approver mismatch");
+    }
+    if approval.expires_at > 0 && e.ledger().timestamp() > approval.expires_at {
+        panic!("governance approval expired");
+    }
+    if approval.category != expected_category {
+        panic!("governance approval category mismatch");
     }
 }
 

--- a/contracts/credence_bond/src/test_liquidation_scanner.rs
+++ b/contracts/credence_bond/src/test_liquidation_scanner.rs
@@ -165,6 +165,48 @@ fn test_pagination_next_cursor_resets_to_zero_on_completion() {
 }
 
 #[test]
+fn test_pagination_remains_stable_after_deregister_between_pages() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    let keeper = Address::generate(&e);
+
+    let a1 = Address::generate(&e);
+    let a2 = Address::generate(&e);
+    let a3 = Address::generate(&e);
+    let a4 = Address::generate(&e);
+    let a5 = Address::generate(&e);
+
+    client.register_bond_holder(&admin, &a1);
+    client.register_bond_holder(&admin, &a2);
+    client.register_bond_holder(&admin, &a3);
+    client.register_bond_holder(&admin, &a4);
+    client.register_bond_holder(&admin, &a5);
+
+    // First page scans slots [0, 2).
+    let page1 = client.scan_liquidation_candidates(&keeper, &0, &2, &0);
+    assert!(!page1.done);
+    assert_eq!(page1.next_cursor, 2);
+    assert_eq!(page1.registry_size, 5);
+
+    // Deregister from an already-scanned slot. Pagination should keep advancing
+    // over stable slot indexes without panicking or rewinding.
+    client.deregister_bond_holder(&admin, &a1);
+    assert_eq!(client.get_registry_size(), 4);
+
+    // Second page scans slots [2, 4).
+    let page2 = client.scan_liquidation_candidates(&keeper, &page1.next_cursor, &2, &0);
+    assert!(!page2.done);
+    assert_eq!(page2.next_cursor, 4);
+    assert_eq!(page2.registry_size, 4);
+
+    // Final page scans slot [4, 5) and completes.
+    let page3 = client.scan_liquidation_candidates(&keeper, &page2.next_cursor, &2, &0);
+    assert!(page3.done);
+    assert_eq!(page3.next_cursor, 0);
+    assert_eq!(page3.registry_size, 4);
+}
+
+#[test]
 fn test_no_candidates_when_no_bonds_active() {
     let e = Env::default();
     let (client, admin) = setup(&e);

--- a/contracts/credence_bond/src/test_parameters.rs
+++ b/contracts/credence_bond/src/test_parameters.rs
@@ -878,3 +878,70 @@ fn test_no_duplicate_events_on_parameter_update() {
         "expected exactly 1 event per setter"
     );
 }
+
+// ============================================================================
+// Category 11: Governance Approval Invariants (issue #278)
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "governance approver mismatch")]
+fn test_parameter_approval_rejects_mismatched_approver() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    let other = Address::generate(&e);
+
+    let approval = GovernanceApproval {
+        approver: other,
+        expires_at: 0,
+        category: symbol_short!("fee"),
+    };
+
+    client.set_protocol_fee_bps_appr(&admin, &100, &approval);
+}
+
+#[test]
+#[should_panic(expected = "governance approval expired")]
+fn test_parameter_approval_rejects_expired_approval() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    e.ledger().with_mut(|li| li.timestamp = 10_000);
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 9_999,
+        category: symbol_short!("risk"),
+    };
+
+    client.set_max_leverage_appr(&admin, &200_000, &approval);
+}
+
+#[test]
+#[should_panic(expected = "governance approval category mismatch")]
+fn test_parameter_approval_rejects_wrong_category() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 0,
+        category: symbol_short!("tier"),
+    };
+
+    client.set_withdrawal_cd_secs_appr(&admin, &3600, &approval);
+}
+
+#[test]
+fn test_parameter_approval_accepts_valid_actor_expiry_and_category() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+
+    e.ledger().with_mut(|li| li.timestamp = 1_000);
+    let approval = GovernanceApproval {
+        approver: admin.clone(),
+        expires_at: 1_100,
+        category: symbol_short!("cooldown"),
+    };
+
+    client.set_slash_cd_secs_appr(&admin, &12_345, &approval);
+    assert_eq!(client.get_slash_cooldown_secs(), 12_345);
+}

--- a/docs/credence-bond.md
+++ b/docs/credence-bond.md
@@ -56,6 +56,18 @@ Managed via `access_control.rs`. All restricted paths emit `access_denied` on un
   3. Check `is_approved(proposal_id)` before attempting to call `execute_slash_if_approved` to save gas.
 - **Storage Keys**: Verifier roles are stored in instance storage as `(Symbol("verifier"), Address)`. Check this before routing verifier-only UI actions.
 
+## 4. Deterministic Ordering Guarantees (Pagination Contract)
+
+List-returning APIs in the bond domain expose deterministic ordering so off-chain pagination cannot duplicate or omit entries due to non-deterministic traversal.
+
+- `scan_liquidation_candidates(keeper, cursor, max_iter, min_slash_ratio_bps)`
+  - Uses a stable slot-indexed registry order.
+  - Deregistration marks identities inactive instead of compacting/removing slots.
+  - Cursor advancement is therefore stable across page boundaries, even when a holder is deregistered between pages.
+  - `registry_size` reports active holders; cursor math is based on stable slot count.
+
+Operational note for indexers: treat `(cursor, next_cursor, done)` as the source of truth for page traversal and do not infer page progression from `registry_size` alone.
+
 ## Function Reference
 
 ### `create_bond_with_rolling(caller, amount, duration)`

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -53,3 +53,17 @@ Slash requests require multi-signature (multi-sig) verification before execution
 - Double voting is rejected.
 - Non-governors and non-delegates cannot vote.
 - Governance is initialized once by admin; governors and quorum are then fixed for the contract instance.
+
+## Parameter Change Approval Invariants
+
+For bond parameter updates that use the explicit approval entrypoints (the `*_appr` methods), the contract enforces three invariants before mutation:
+
+- **Approver/actor binding**: `approval.approver` must equal the `admin` actor executing the change.
+- **Expiry**: if `approval.expires_at > 0`, execution must occur at or before the expiry timestamp.
+- **Category mapping**: `approval.category` must match the target parameter family:
+	- `fee`: protocol fee, attestation fee
+	- `cooldown`: withdrawal cooldown, slash cooldown
+	- `tier`: bronze/silver/gold/platinum thresholds
+	- `risk`: max leverage, borrow freeze
+
+These checks prevent stale approvals, actor substitution, and cross-category reuse of approvals.


### PR DESCRIPTION
Preserve stable pagination order in liquidation scanner by keeping registry slots stable across deregistration.
Track active holders separately instead of compacting the registry vector to prevent cursor drift.
Ensure cursor validation uses stable slot bounds while reporting active registry size in scan results.
Add regression coverage for deregistration between pages to prove no duplicate/omitted traversal.
Document deterministic ordering and pagination contract behavior for indexers.

Closes #269