### PR TITLE
feat: prevent delegation pause-governance lockout

### DIFF
--- a/contracts/credence_delegation/src/pausable.rs
+++ b/contracts/credence_delegation/src/pausable.rs
@@ -38,6 +38,11 @@ pub fn require_not_paused(e: &Env) {
 pub fn set_pause_signer(e: &Env, admin: &Address, signer: &Address, enabled: bool) {
     require_admin_auth(e, admin);
 
+    // No-lockout invariants:
+    // 1. If there are active signers (count > 0), threshold MUST be > 0.
+    // 2. Threshold MUST be <= signer count.
+    // 3. Unpause MUST ALWAYS be reachable (admin override is available).
+
     let key = DataKey::PauseSigner(signer.clone());
     let existing: bool = e.storage().instance().get(&key).unwrap_or(false);
 
@@ -52,6 +57,16 @@ pub fn set_pause_signer(e: &Env, admin: &Address, signer: &Address, enabled: boo
             e.storage()
                 .instance()
                 .set(&DataKey::PauseSignerCount, &count.saturating_add(1));
+
+            // Auto-adjust threshold to 1 if it is currently 0, to maintain no-lockout invariant
+            let threshold: u32 = e
+                .storage()
+                .instance()
+                .get(&DataKey::PauseThreshold)
+                .unwrap_or(0);
+            if threshold == 0 {
+                e.storage().instance().set(&DataKey::PauseThreshold, &1_u32);
+            }
         }
     } else if existing {
         e.storage().instance().remove(&key);
@@ -96,6 +111,9 @@ pub fn set_pause_threshold(e: &Env, admin: &Address, threshold: u32) {
         .unwrap_or(0);
     if threshold > count {
         panic_with_error!(e, ContractError::ThresholdExceedsSigners);
+    }
+    if threshold == 0 && count > 0 {
+        panic_with_error!(e, ContractError::InvalidPauseAction);
     }
     e.storage()
         .instance()
@@ -176,6 +194,19 @@ pub fn unpause(e: &Env, caller: &Address) -> Option<u64> {
         do_unpause(e, None);
         None
     } else {
+        // Admin override: Admin can always unpause without a proposal.
+        let stored_admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+        if *caller == stored_admin {
+            caller.require_auth();
+            do_unpause(e, None);
+            return None;
+        }
+
         propose_action(e, caller, PauseAction::Unpause)
     }
 }

--- a/contracts/credence_delegation/src/test_pausable.rs
+++ b/contracts/credence_delegation/src/test_pausable.rs
@@ -187,3 +187,57 @@ fn test_invalidate_nonce_range_paused() {
     client.pause(&admin);
     assert!(client.try_invalidate_nonce_range(&owner, &100_u64).is_err());
 }
+
+#[test]
+fn test_admin_can_always_unpause() {
+    let (env, admin, client) = setup();
+
+    let s1 = Address::generate(&env);
+
+    client.set_pause_signer(&admin, &s1, &true);
+    // threshold auto-adjusts to 1
+
+    let pid = client.pause(&s1).unwrap();
+    client.execute_pause_proposal(&pid);
+    assert!(client.is_paused());
+
+    // Even though there are signers and threshold > 0, admin can bypass and unpause directly
+    let res = client.unpause(&admin);
+    assert!(res.is_none());
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_threshold_invariants() {
+    let (env, admin, client) = setup();
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+
+    // Initial threshold is 0
+
+    client.set_pause_signer(&admin, &s1, &true);
+    // Threshold should automatically be 1
+
+    // Setting threshold to 0 when signers exist should fail
+    let res = client.try_set_pause_threshold(&admin, &0);
+    assert!(res.is_err());
+
+    client.set_pause_signer(&admin, &s2, &true);
+
+    client.set_pause_threshold(&admin, &2);
+
+    // Removing signers lowers threshold
+    client.set_pause_signer(&admin, &s2, &false);
+    // threshold should now be 1
+
+    client.set_pause_signer(&admin, &s1, &false);
+    // threshold should now be 0, as there are no signers, which makes count 0
+    // Actually the code does not auto-lower to 0 unless threshold > new_count.
+    // If threshold was 1, new_count is 0, so threshold becomes 0.
+
+    // We can verify this by checking if admin can pause directly without proposal
+    let res = client.pause(&admin);
+    assert!(res.is_none());
+    assert!(client.is_paused());
+}

--- a/docs/emergency.md
+++ b/docs/emergency.md
@@ -109,6 +109,12 @@ contract.approve_pause_proposal(signer2_address, proposal_id);
 contract.execute_pause_proposal(proposal_id);
 ```
 
+### Emergency Admin Unpause Override
+```rust
+// Admin can bypass the multisig threshold and unpause the contract directly to prevent governance lockout.
+contract.unpause(admin_address);
+```
+
 ## Configuration Recommendations
 
 ### Production Environment
@@ -127,7 +133,8 @@ contract.execute_pause_proposal(proposal_id);
 All pause mechanism implementations include comprehensive tests covering:
 - Basic pause/unpause functionality
 - Multi-signature proposal workflow
-- Threshold enforcement
+- Threshold enforcement and invariants (no-lockout)
+- Admin override for unpausing
 - Read-only operation preservation
 - State-changing operation blocking
 - Error conditions and edge cases

--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -354,8 +354,10 @@ client.remove_signer(&admin, &compromised_signer);
 
 ### Threshold Safety
 - Threshold must always be: 1 ≤ threshold ≤ signer count
+- Automatic threshold adjustment to 1 when first signer is added
 - Automatic threshold adjustment when removing signers
-- Cannot remove last signer
+- Cannot remove last signer without setting threshold appropriately (governance lockout protections)
+- Admin can override and directly execute an unpause action when required
 
 ### Overflow Protection
 - All arithmetic operations use checked arithmetic


### PR DESCRIPTION
Closes #374


Guard pause threshold to be > 0 with at least one active signer and test lockout. Ensured admin can always unpause. Updated docs and tests appropriately.