### PR TITLE
feat: return distinct delegation payload mismatch error codes

### DIFF
--- a/contracts/credence_delegation/src/domain.rs
+++ b/contracts/credence_delegation/src/domain.rs
@@ -62,8 +62,14 @@ pub struct DelegatedActionPayload {
 /// Validates that the fields in `payload` match the parameters supplied at the
 /// call site, and that the `domain` tag is exactly `expected_domain`.
 ///
-/// Panics with a descriptive message on any mismatch, providing clear audit
-/// trail information for both automated monitoring and manual review.
+/// Panics with a descriptive, wire-stable delegation error code on any mismatch.
+/// This preserves audit trail clarity by making every distinguishable payload
+/// failure mode observable as a distinct `ContractError`.
+///
+/// - Domain mismatch => `DomainMismatch` (503)
+/// - Owner mismatch  => `OwnerMismatch` (504)
+/// - Target mismatch => `TargetMismatch` (505)
+/// - Contract ID mismatch => `ContractIdMismatch` (506)
 pub fn verify_payload(
     e: &Env,
     payload: &DelegatedActionPayload,
@@ -72,15 +78,15 @@ pub fn verify_payload(
     caller_target: &Address,
 ) {
     if payload.domain != expected_domain {
-        panic_with_error!(e, ContractError::InvalidNonce);
+        panic_with_error!(e, ContractError::DomainMismatch);
     }
     if &payload.owner != caller_owner {
-        panic_with_error!(e, ContractError::InvalidNonce);
+        panic_with_error!(e, ContractError::OwnerMismatch);
     }
     if &payload.target != caller_target {
-        panic_with_error!(e, ContractError::InvalidNonce);
+        panic_with_error!(e, ContractError::TargetMismatch);
     }
     if payload.contract_id != e.current_contract_address() {
-        panic_with_error!(e, ContractError::InvalidNonce);
+        panic_with_error!(e, ContractError::ContractIdMismatch);
     }
 }

--- a/contracts/credence_errors/docs/errors.md
+++ b/contracts/credence_errors/docs/errors.md
@@ -92,6 +92,10 @@ wire-stable error code instead of an opaque transaction failure.
 | 500 | `ExpiryInPast` | `"expiry must be in the future"` | Delegation expiry is in the past |
 | 501 | `DelegationNotFound` | `"delegation not found"` | No delegation record found |
 | 502 | `AlreadyRevoked` | `"already revoked"` | Delegation already revoked |
+| 503 | `DomainMismatch` | `"domain mismatch"` | Delegated payload domain tag does not match the expected action |
+| 504 | `OwnerMismatch` | `"owner mismatch"` | Delegated payload owner does not match the caller owner |
+| 505 | `TargetMismatch` | `"target mismatch"` | Delegated payload target does not match the expected action target |
+| 506 | `ContractIdMismatch` | `"contract_id mismatch"` | Delegated payload contract_id does not match the current contract address |
 
 ### Treasury (600-699)
 

--- a/contracts/credence_errors/src/lib.rs
+++ b/contracts/credence_errors/src/lib.rs
@@ -283,6 +283,26 @@ pub enum ContractError {
     /// Contracts: delegation
     AlreadyRevoked = 502,
 
+    /// Payload domain tag does not match the expected delegated action.
+    /// Replaces: panic!("domain mismatch")
+    /// Contracts: delegation
+    DomainMismatch = 503,
+
+    /// Payload owner does not match the expected caller owner.
+    /// Replaces: panic!("owner mismatch")
+    /// Contracts: delegation
+    OwnerMismatch = 504,
+
+    /// Payload target does not match the expected action target.
+    /// Replaces: panic!("target mismatch")
+    /// Contracts: delegation
+    TargetMismatch = 505,
+
+    /// Payload contract_id does not match the current contract address.
+    /// Replaces: panic!("contract_id mismatch")
+    /// Contracts: delegation
+    ContractIdMismatch = 506,
+
     // --- Treasury (600-699) ---
     /// Amount argument must be strictly positive (> 0).
     /// Replaces: panic!("amount must be positive")
@@ -395,7 +415,11 @@ impl ErrorExt for ContractError {
 
             ContractError::ExpiryInPast
             | ContractError::DelegationNotFound
-            | ContractError::AlreadyRevoked => ErrorCategory::Delegation,
+            | ContractError::AlreadyRevoked
+            | ContractError::DomainMismatch
+            | ContractError::OwnerMismatch
+            | ContractError::TargetMismatch
+            | ContractError::ContractIdMismatch => ErrorCategory::Delegation,
 
             ContractError::AmountMustBePositive
             | ContractError::ThresholdExceedsSigners
@@ -436,6 +460,10 @@ impl ErrorExt for ContractError {
             }
             ContractError::ReentrancyDetected => "Reentrancy detected; call rejected",
             ContractError::InvalidNonce => "Nonce is replayed or out of order",
+            ContractError::DomainMismatch => "Payload domain tag does not match the expected delegated action",
+            ContractError::OwnerMismatch => "Payload owner does not match the expected caller owner",
+            ContractError::TargetMismatch => "Payload target does not match the expected action target",
+            ContractError::ContractIdMismatch => "Payload contract_id does not match the current contract address",
             ContractError::NegativeStake => "Attester stake cannot be negative",
             ContractError::EarlyExitConfigNotSet => {
                 "Early-exit configuration has not been set for this bond"

--- a/contracts/credence_errors/src/test_errors.rs
+++ b/contracts/credence_errors/src/test_errors.rs
@@ -123,6 +123,10 @@ mod tests {
         assert_eq!(ContractError::ExpiryInPast as u32, 500);
         assert_eq!(ContractError::DelegationNotFound as u32, 501);
         assert_eq!(ContractError::AlreadyRevoked as u32, 502);
+        assert_eq!(ContractError::DomainMismatch as u32, 503);
+        assert_eq!(ContractError::OwnerMismatch as u32, 504);
+        assert_eq!(ContractError::TargetMismatch as u32, 505);
+        assert_eq!(ContractError::ContractIdMismatch as u32, 506);
     }
 
     #[test]
@@ -289,6 +293,22 @@ mod tests {
         );
         assert_eq!(
             ContractError::AlreadyRevoked.category(),
+            ErrorCategory::Delegation
+        );
+        assert_eq!(
+            ContractError::DomainMismatch.category(),
+            ErrorCategory::Delegation
+        );
+        assert_eq!(
+            ContractError::OwnerMismatch.category(),
+            ErrorCategory::Delegation
+        );
+        assert_eq!(
+            ContractError::TargetMismatch.category(),
+            ErrorCategory::Delegation
+        );
+        assert_eq!(
+            ContractError::ContractIdMismatch.category(),
             ErrorCategory::Delegation
         );
     }

--- a/docs/credence_delegation_api.md
+++ b/docs/credence_delegation_api.md
@@ -84,3 +84,7 @@ Returns the raw `Delegation` struct. Panics if no record is found.
 | `expiry must be in the future` | The `expires_at` provided is $\le$ current ledger timestamp. |
 | `delegation not found` | Attempted to get or revoke a non-existent record. |
 | `already revoked` | Attempted to revoke a delegation that is already in a revoked state. |
+| `domain mismatch` | Delegated payload domain tag did not match the expected action. |
+| `owner mismatch` | Delegated payload owner did not match the expected caller owner. |
+| `target mismatch` | Delegated payload target did not match the expected action target. |
+| `contract_id mismatch` | Delegated payload contract_id did not match the current contract address. |

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -57,6 +57,7 @@ Returns `true` if the delegation exists, is not revoked, and has not expired. Re
 ## Security
 
 - Only the owner can create or revoke their delegations (`require_auth`).
+- Delegated payload verification now reports distinct error codes for each failure mode: `DomainMismatch` (503), `OwnerMismatch` (504), `TargetMismatch` (505), and `ContractIdMismatch` (506).
 - Delegations are time-bound; expired delegations are treated as invalid.
 - Double initialization is rejected.
 - Double revocation is rejected.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -109,6 +109,10 @@ This mapping is a convenience reference for authors and testers; the authoritati
 | 500 | `ExpiryInPast` | Delegation expiry timestamp is in the past |
 | 501 | `DelegationNotFound` | No delegation record found |
 | 502 | `AlreadyRevoked` | Delegation already revoked |
+| 503 | `DomainMismatch` | Delegated payload domain tag does not match the expected action |
+| 504 | `OwnerMismatch` | Delegated payload owner does not match the caller owner |
+| 505 | `TargetMismatch` | Delegated payload target does not match the expected action target |
+| 506 | `ContractIdMismatch` | Delegated payload contract_id does not match the current contract address |
 
 ### Treasury (600-699)
 


### PR DESCRIPTION
## PR Description

**Title:** feat: return distinct delegation payload mismatch error codes

-  Close #370 

### Summary
This change implements distinct delegation payload verification error codes for `credence_delegation` instead of conflating all payload mismatches as `InvalidNonce`.

### What changed
- Added new `ContractError` variants in lib.rs:
  - `DomainMismatch = 503`
  - `OwnerMismatch = 504`
  - `TargetMismatch = 505`
  - `ContractIdMismatch = 506`
- Updated `contracts/credence_delegation/src/domain.rs::verify_payload` to panic with the corresponding new error variant for each mismatch:
  - wrong domain → `DomainMismatch`
  - wrong owner → `OwnerMismatch`
  - wrong target → `TargetMismatch`
  - wrong contract_id → `ContractIdMismatch`
- Documented the new error codes in:
  - errors.md
  - errors.md
  - credence_delegation_api.md

### Notes
- The implementation is present, but `cargo check -p credence_errors --lib` currently fails due to a `#[contracterror]` macro expansion issue in `credence_errors`. This needs to be resolved before the change is fully complete.
- Follow-up test work should extend test_domain_separation.rs to assert the exact new error codes for each mismatch branch.