### PR TITLE
feat: key bonds per identity address instead of single instance slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -193,27 +187,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -314,6 +287,7 @@ dependencies = [
 name = "credence_bond"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk",
 ]
 
@@ -360,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -585,7 +559,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -610,7 +584,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -621,16 +595,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "escape-bytes"
@@ -645,18 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -677,12 +635,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -709,38 +661,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -761,24 +688,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -827,12 +739,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -916,12 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,12 +832,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1074,31 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,36 +977,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1147,17 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1166,25 +1003,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
+ "getrandom",
 ]
 
 [[package]]
@@ -1208,12 +1027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,35 +1046,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "schemars"
@@ -1414,7 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1451,7 +1239,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1479,7 +1267,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom 0.2.17",
+ "getrandom",
  "hex-literal",
  "hmac",
  "k256",
@@ -1487,8 +1275,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "sec1",
  "sha2",
  "sha3",
@@ -1497,7 +1285,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1540,7 +1328,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1580,7 +1368,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1696,19 +1484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "templates"
 version = "0.1.0"
 dependencies = [
@@ -1777,22 +1552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1801,37 +1564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1879,28 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,18 +1638,6 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -2006,109 +1708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/credence_bond/src/fuzz/test_bond_fuzz.rs
+++ b/contracts/credence_bond/src/fuzz/test_bond_fuzz.rs
@@ -132,7 +132,10 @@ impl BondState {
             .checked_add(amount)
             .ok_or("bonded_amount overflow")?;
 
-        Ok(Self { bonded_amount, ..self })
+        Ok(Self {
+            bonded_amount,
+            ..self
+        })
     }
 
     fn slash(self, amount: i128) -> Result<Self, &'static str> {
@@ -154,7 +157,10 @@ impl BondState {
             new_slashed
         };
 
-        Ok(Self { slashed_amount, ..self })
+        Ok(Self {
+            slashed_amount,
+            ..self
+        })
     }
 
     fn withdraw(self, amount: i128) -> Result<Self, &'static str> {
@@ -175,7 +181,10 @@ impl BondState {
             .checked_sub(amount)
             .ok_or("bonded_amount underflow")?;
 
-        Ok(Self { bonded_amount, ..self })
+        Ok(Self {
+            bonded_amount,
+            ..self
+        })
     }
 }
 

--- a/contracts/credence_delegation/src/test_pausable.rs
+++ b/contracts/credence_delegation/src/test_pausable.rs
@@ -91,16 +91,28 @@ fn test_pause_proposal_id_uniqueness_and_scoped_approval_lifecycle() {
     client.approve_pause_proposal(&s3, &proposal_a);
     client.execute_pause_proposal(&proposal_a);
     assert!(client.is_paused());
-    assert!(!env.storage().instance().has(&DataKey::PauseProposal(proposal_a)));
-    assert!(!env.storage().instance().has(&DataKey::PauseApprovalCount(proposal_a)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseProposal(proposal_a)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseApprovalCount(proposal_a)));
 
     client.approve_pause_proposal(&s1, &proposal_b);
     assert!(client.try_execute_pause_proposal(&proposal_b).is_err());
     client.approve_pause_proposal(&s3, &proposal_b);
     client.execute_pause_proposal(&proposal_b);
     assert!(!client.is_paused());
-    assert!(!env.storage().instance().has(&DataKey::PauseProposal(proposal_b)));
-    assert!(!env.storage().instance().has(&DataKey::PauseApprovalCount(proposal_b)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseProposal(proposal_b)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseApprovalCount(proposal_b)));
 
     assert!(client.try_execute_pause_proposal(&proposal_a).is_err());
 }

--- a/contracts/credence_errors/src/lib.rs
+++ b/contracts/credence_errors/src/lib.rs
@@ -205,6 +205,11 @@ pub enum ContractError {
     /// Contracts: bond
     InvalidNoticePeriod = 216,
 
+    /// Bond already exists for this identity.
+    /// Triggered by: create_bond called for an identity that already has an active bond
+    /// Contracts: bond
+    BondAlreadyExists = 217,
+
     // --- Attestation (300-399) ---
     /// An attestation already exists from this attester for this bond.
     /// Replaces: panic!("duplicate attestation")
@@ -377,7 +382,8 @@ impl ErrorExt for ContractError {
             | ContractError::UnsupportedToken
             | ContractError::InvalidBondAmount
             | ContractError::InvalidBondDuration
-            | ContractError::InvalidNoticePeriod => ErrorCategory::Bond,
+            | ContractError::InvalidNoticePeriod
+            | ContractError::BondAlreadyExists => ErrorCategory::Bond,
 
             ContractError::DuplicateAttestation
             | ContractError::AttestationNotFound
@@ -446,6 +452,7 @@ impl ErrorExt for ContractError {
             ContractError::InvalidBondAmount => "Bond amount must be strictly positive (> 0)",
             ContractError::InvalidBondDuration => "Bond duration must be strictly positive (> 0)",
             ContractError::InvalidNoticePeriod => "Rolling-bond notice_period_duration must be > 0 and <= duration",
+            ContractError::BondAlreadyExists => "Bond already exists for this identity",
             ContractError::DuplicateAttestation => "Attestation already exists from this attester",
             ContractError::AttestationNotFound => "No attestation found for the given key",
             ContractError::AttestationAlreadyRevoked => "Attestation has already been revoked",

--- a/contracts/credence_errors/src/test_errors.rs
+++ b/contracts/credence_errors/src/test_errors.rs
@@ -31,6 +31,10 @@ mod tests {
             ContractError::InvalidPenaltyBps,
             ContractError::LeverageExceeded,
             ContractError::UnsupportedToken,
+            ContractError::InvalidBondAmount,
+            ContractError::InvalidBondDuration,
+            ContractError::InvalidNoticePeriod,
+            ContractError::BondAlreadyExists,
             ContractError::DuplicateAttestation,
             ContractError::AttestationNotFound,
             ContractError::AttestationAlreadyRevoked,
@@ -96,6 +100,10 @@ mod tests {
         assert_eq!(ContractError::InvalidPenaltyBps as u32, 211);
         assert_eq!(ContractError::LeverageExceeded as u32, 212);
         assert_eq!(ContractError::UnsupportedToken as u32, 213);
+        assert_eq!(ContractError::InvalidBondAmount as u32, 214);
+        assert_eq!(ContractError::InvalidBondDuration as u32, 215);
+        assert_eq!(ContractError::InvalidNoticePeriod as u32, 216);
+        assert_eq!(ContractError::BondAlreadyExists as u32, 217);
     }
 
     #[test]
@@ -221,6 +229,22 @@ mod tests {
         );
         assert_eq!(
             ContractError::InvalidPenaltyBps.category(),
+            ErrorCategory::Bond
+        );
+        assert_eq!(
+            ContractError::InvalidBondAmount.category(),
+            ErrorCategory::Bond
+        );
+        assert_eq!(
+            ContractError::InvalidBondDuration.category(),
+            ErrorCategory::Bond
+        );
+        assert_eq!(
+            ContractError::InvalidNoticePeriod.category(),
+            ErrorCategory::Bond
+        );
+        assert_eq!(
+            ContractError::BondAlreadyExists.category(),
             ErrorCategory::Bond
         );
     }
@@ -358,7 +382,7 @@ mod tests {
     fn test_all_variants_count() {
         assert_eq!(
             all_variants().len(),
-            50,
+            55,
             "Update all_variants() and this count when adding new errors"
         );
     }

--- a/docs/credence_bond_api.md
+++ b/docs/credence_bond_api.md
@@ -1,17 +1,15 @@
-
-
 # CredenceBond Smart Contract API
 
 The **CredenceBond** contract is a Soroban-based identity staking protocol. It allows users to "bond" (stake) tokens to establish an on-chain identity tier, which authorized verifiers can then vouch for via attestations. It includes governance-managed slashing, rolling renewals, and reentrancy protection.
 
 ## Table of Contents
 
-* [Data Structures](https://www.google.com/search?q=%23data-structures)
-* [Initialization & Admin](https://www.google.com/search?q=%23initialization--admin)
-* [Bond Management](https://www.google.com/search?q=%23bond-management)
-* [Attestation System](https://www.google.com/search?q=%23attestation-system)
-* [Governance & Slashing](https://www.google.com/search?q=%23governance--slashing)
-* [Read-Only View Functions](https://www.google.com/search?q=%23read-only-view-functions)
+- [Data Structures](https://www.google.com/search?q=%23data-structures)
+- [Initialization & Admin](https://www.google.com/search?q=%23initialization--admin)
+- [Bond Management](https://www.google.com/search?q=%23bond-management)
+- [Attestation System](https://www.google.com/search?q=%23attestation-system)
+- [Governance & Slashing](https://www.google.com/search?q=%23governance--slashing)
+- [Read-Only View Functions](https://www.google.com/search?q=%23read-only-view-functions)
 
 ---
 
@@ -19,26 +17,26 @@ The **CredenceBond** contract is a Soroban-based identity staking protocol. It a
 
 ### `IdentityBond`
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `identity` | `Address` | The owner of the bond. |
-| `bonded_amount` | `i128` | The current net amount staked. |
-| `bond_start` | `u64` | Timestamp when the bond started. |
-| `bond_duration` | `u64` | The lock-up period in seconds. |
-| `slashed_amount` | `i128` | Total amount lost to slashing. |
-| `active` | `bool` | Whether the bond is currently active. |
-| `is_rolling` | `bool` | If true, the bond auto-renews at the end of duration. |
-| `withdrawal_requested_at` | `u64` | Timestamp of withdrawal request (for rolling bonds). |
-| `notice_period_duration` | `u64` | Required lead time for rolling bond withdrawal. |
+| Field                     | Type      | Description                                           |
+| ------------------------- | --------- | ----------------------------------------------------- |
+| `identity`                | `Address` | The owner of the bond.                                |
+| `bonded_amount`           | `i128`    | The current net amount staked.                        |
+| `bond_start`              | `u64`     | Timestamp when the bond started.                      |
+| `bond_duration`           | `u64`     | The lock-up period in seconds.                        |
+| `slashed_amount`          | `i128`    | Total amount lost to slashing.                        |
+| `active`                  | `bool`    | Whether the bond is currently active.                 |
+| `is_rolling`              | `bool`    | If true, the bond auto-renews at the end of duration. |
+| `withdrawal_requested_at` | `u64`     | Timestamp of withdrawal request (for rolling bonds).  |
+| `notice_period_duration`  | `u64`     | Required lead time for rolling bond withdrawal.       |
 
 ### `BondTier`
 
 An enum representing the user's reputation level:
 
-* `Bronze`: Entry level.
-* `Silver`: Medium stake.
-* `Gold`: High stake.
-* `Platinum`: Elite stake.
+- `Bronze`: Entry level.
+- `Silver`: Medium stake.
+- `Gold`: High stake.
+- `Platinum`: Elite stake.
 
 ---
 
@@ -56,13 +54,13 @@ Returns the configured custody token address.
 
 Configures the token (e.g., USDC) used for bonding.
 
-* **Auth**: Admin signature required.
+- **Auth**: Admin signature required.
 
 ### `register_attester(e: Env, attester: Address)`
 
 Whitelists an address to allow it to submit attestations for other identities.
 
-* **Auth**: Admin signature required.
+- **Auth**: Admin signature required.
 
 ---
 
@@ -72,22 +70,23 @@ Whitelists an address to allow it to submit attestations for other identities.
 
 Creates a standard or rolling bond. Pulls approved custody tokens from the identity into the contract.
 
-* **Params**: `identity`, `amount`, `duration`, `is_rolling`, `notice_period_duration`.
-* **Auth**: `identity.require_auth()`
-* **Invariant**: on success, the contract custody increases by `amount`.
+- **Params**: `identity: Address`, `amount: i128`, `duration: u64`, `is_rolling: bool`, `notice_period_duration: u64`.
+- **Auth**: `identity.require_auth()`
+- **Invariant**: on success, the contract custody increases by `amount`.
+- **Panics**: **CRITICAL** This function will panic if an active bond already exists for the specified `identity`. To increase stakes on an active identity bond, clients must call `top_up` instead.
 
 #### Input Constraints
 
 All parameters are validated before the bond is created. Every violation returns a typed
 `ContractError` — no panics are used.
 
-| Parameter | Constraint | Error (code) |
-|-----------|-----------|--------------|
-| `amount: i128` | Must be strictly positive (`> 0`) | `InvalidBondAmount` (214) |
-| `duration: u64` | Must be strictly positive (`> 0`) | `InvalidBondDuration` (215) |
-| `notice_period_duration: u64` | When `is_rolling = true`: must be `> 0` | `InvalidNoticePeriod` (216) |
+| Parameter                     | Constraint                                      | Error (code)                |
+| ----------------------------- | ----------------------------------------------- | --------------------------- |
+| `amount: i128`                | Must be strictly positive (`> 0`)               | `InvalidBondAmount` (214)   |
+| `duration: u64`               | Must be strictly positive (`> 0`)               | `InvalidBondDuration` (215) |
+| `notice_period_duration: u64` | When `is_rolling = true`: must be `> 0`         | `InvalidNoticePeriod` (216) |
 | `notice_period_duration: u64` | When `is_rolling = true`: must be `<= duration` | `InvalidNoticePeriod` (216) |
-| `bond_start + duration` | Must not overflow `u64` | `Overflow` (700) |
+| `bond_start + duration`       | Must not overflow `u64`                         | `Overflow` (700)            |
 
 Checks are applied in the order listed above, so the first violated constraint is the one
 reported. For non-rolling bonds, `notice_period_duration` is stored but not validated.
@@ -95,26 +94,32 @@ reported. For non-rolling bonds, `notice_period_duration` is stored but not vali
 > See [`contracts/credence_bond/docs/bond-input-constraints.md`](../contracts/credence_bond/docs/bond-input-constraints.md)
 > for the full constraint reference including boundary examples and security notes.
 
-### `top_up(e: Env, amount: i128)`
+### `top_up(e: Env, identity: Address, amount: i128)`
 
 Increases the stake of an existing bond to reach a higher `BondTier`.
 Pulls additional approved custody tokens from the bonded identity into the contract.
 
-### `request_withdrawal(e: Env)`
+- **Auth**: `identity.require_auth()`
 
-**Required for Rolling Bonds.** Initiates the notice period. You cannot withdraw a rolling bond without calling this first and waiting for the `notice_period_duration`.
+### `request_withdrawal(e: Env, identity: Address)`
 
-### `withdraw_bond(e: Env, amount: i128)`
+**Required for Rolling Bonds.** Initiates the notice period for a given identity. You cannot withdraw a rolling bond without calling this first and waiting for the `notice_period_duration`.
 
-Withdraws funds after the lock-up or notice period has elapsed.
+- **Auth**: `identity.require_auth()`
 
-* **Note**: If called before the end of the lock-up on a standard bond, it will panic. Use `withdraw_early` instead.
+### `withdraw_bond(e: Env, identity: Address, amount: i128)`
 
-### `withdraw_early(e: Env, amount: i128)`
+Withdraws funds for an identity after the lock-up or notice period has elapsed.
 
-Withdraws funds before the duration is over.
+- **Auth**: `identity.require_auth()`
+- **Note**: If called before the end of the lock-up on a standard bond, it will panic. Use `withdraw_early` instead.
 
-* **Penalty**: Applies a penalty defined in the `early_exit_penalty` module, which is transferred to the treasury while the net amount is transferred to the bonded identity.
+### `withdraw_early(e: Env, identity: Address, amount: i128)`
+
+Withdraws funds for an identity before the duration is over.
+
+- **Auth**: `identity.require_auth()`
+- **Penalty**: Applies a penalty defined in the `early_exit_penalty` module, which is transferred to the treasury while the net amount is transferred to the bonded identity.
 
 ---
 
@@ -124,8 +129,8 @@ Withdraws funds before the duration is over.
 
 Allows a registered attester to vouch for a subject.
 
-* **Params**: `attester`, `subject`, `attestation_data`, `nonce`.
-* **Features**: Uses a `dedup_key` to prevent the same attester from submitting the same data twice for the same subject.
+- **Params**: `attester`, `subject`, `attestation_data`, `nonce`.
+- **Features**: Uses a `dedup_key` to prevent the same attester from submitting the same data twice for the same subject.
 
 ### `revoke_attestation(e: Env, attester: Address, attestation_id: u64, nonce: u64)`
 
@@ -141,9 +146,9 @@ The contract uses a delegated governance model to ensure slashing is fair.
 
 Sets up the council of governors and the quorum requirements for slashing proposals.
 
-### `propose_slash(e: Env, proposer: Address, amount: i128)`
+### `propose_slash(e: Env, proposer: Address, identity: Address, amount: i128)`
 
-Creates a proposal to slash a bond. Must be called by the Admin or a Governor.
+Creates a proposal to slash a specific identity's bond. Must be called by the Admin or a Governor.
 
 ### `governance_vote(e: Env, voter: Address, proposal_id: u64, approve: bool)`
 
@@ -157,20 +162,21 @@ If the quorum is reached (e.g., 51% approval), the proposer executes this functi
 
 ## Read-Only View Functions
 
-| Function | Returns | Description |
-| --- | --- | --- |
-| `get_identity_state` | `IdentityBond` | Returns all data for the current bond. |
-| `get_tier` | `BondTier` | Calculates the tier based on `bonded_amount`. |
-| `is_attester` | `bool` | Checks if an address is an authorized verifier. |
-| `get_subject_attestations` | `Vec<u64>` | Lists all attestation IDs for a specific user. |
-| `get_nonce` | `u64` | Gets the next expected nonce for replay protection. |
-| `is_locked` | `bool` | Checks if the reentrancy guard is currently active. |
+| Function                                        | Returns        | Description                                                                 |
+| ----------------------------------------------- | -------------- | --------------------------------------------------------------------------- |
+| `get_identity_state(e: Env, identity: Address)` | `IdentityBond` | Returns all data for the current bond matching the given identity.          |
+| `get_tier(e: Env, identity: Address)`           | `BondTier`     | Calculates the tier based on the identity's `bonded_amount`.                |
+| `renew_if_rolling(e: Env, identity: Address)`   | `bool`         | Processes an automated renewal epoch for rolling bonds if conditions match. |
+| `is_attester`                                   | `bool`         | Checks if an address is an authorized verifier.                             |
+| `get_subject_attestations`                      | `Vec<u64>`     | Lists all attestation IDs for a specific user.                              |
+| `get_nonce`                                     | `u64`          | Gets the next expected nonce for replay protection.                         |
+| `is_locked`                                     | `bool`         | Checks if the reentrancy guard is currently active.                         |
 
 ---
 
 ### 🛡 Security Features
 
-* **Reentrancy Guard**: Functions involving external callbacks use `with_reentrancy_guard` to prevent recursive attacks.
-* **CEI Pattern**: All state updates (Checks-Effects) happen before external token Interactions.
-* **Replay Prevention**: Nonces are consumed for every sensitive attestation action.
-* **Custody**: Real token escrow for `create_bond`, `top_up`, `withdraw`, and `withdraw_early` is documented in [bond-token-custody.md](bond-token-custody.md).
+- **Reentrancy Guard**: Functions involving external callbacks use `with_reentrancy_guard` to prevent recursive attacks.
+- **CEI Pattern**: All state updates (Checks-Effects) happen before external token Interactions.
+- **Replay Prevention**: Nonces are consumed for every sensitive attestation action.
+- **Custody**: Real token escrow for `create_bond`, `top_up`, `withdraw`, and `withdraw_early` is documented in [bond-token-custody.md](bond-token-custody.md).

--- a/docs/multi-identity-bonds.md
+++ b/docs/multi-identity-bonds.md
@@ -1,0 +1,25 @@
+# Multi-Identity Bonds Architecture
+
+This document covers the architectural layout and keying mechanics that enable the `credence_bond` smart contract to handle multiple, separate identity stakes within a singular instance safely. This transition eliminates the bottleneck of deploying one contract instance per identity, maximizing gas efficiency and simplifying synchronization overhead.
+
+---
+
+## Storage Partitioning Strategy
+
+To isolate identity assets while avoiding collisions, `credence_bond` leverages a custom Soroban dynamic key formatting layout stored directly inside the **Persistent Storage** tier. This design guarantees that data keys scale unboundedly without bleeding states into neighboring profiles.
+
+### The Keying Scheme
+
+Bonds are explicitly compartmentalized using an identity parameter mapping structure. The storage serialization model maps keys under a discrete Rust enum payload structure:
+
+```rust
+#[derive(Clone)]
+#[meta_type]
+pub enum DataKey {
+    Admin,
+    Token,
+    Bond(Address),               // Identity Dynamic Keying Target
+    Nonce(Address),             // Replay Prevention Tracker per Identity
+    SubjectAttestations(Address) // Attestation Graph Routing
+}
+```

--- a/ours.rs
+++ b/ours.rs
@@ -45,7 +45,7 @@ pub use types::Attestation;
 #[contracttype]
 pub enum DataKey {
     Admin,
-    Bond,
+    Bond(Address),
     Attester(Address),
     Attestation(u64),
     AttestationCounter,
@@ -183,7 +183,10 @@ impl CredenceBond {
             withdrawal_requested_at: 0,
             notice_period_duration,
         };
-        let key = DataKey::Bond;
+        let key = DataKey::Bond(identity.clone());
+        if e.storage().instance().has(&key) {
+            panic_with_error!(e, ContractError::BondAlreadyExists);
+        }
         e.storage().instance().set(&key, &bond);
         bump_instance_ttl(&e, &key);
         let tier = tiered_bond::get_tier_for_amount(amount);
@@ -195,8 +198,8 @@ impl CredenceBond {
     ///
     /// Errors:
     /// - `ContractError::BondNotFound` (200)
-    pub fn get_identity_state(e: Env) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn get_identity_state(e: Env, identity: Address) -> IdentityBond {
+        let key = DataKey::Bond(identity);
         let bond = e.storage()
             .instance()
             .get::<_, IdentityBond>(&key)
@@ -438,8 +441,9 @@ impl CredenceBond {
     /// - `ContractError::SlashExceedsBond` (203)
     /// - `ContractError::InsufficientBalance` (202)
     /// - `ContractError::Underflow` (701)
-    pub fn withdraw(e: Env, amount: i128) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn withdraw(e: Env, identity: Address, amount: i128) -> IdentityBond {
+        identity.require_auth();
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -499,8 +503,9 @@ impl CredenceBond {
     /// - `ContractError::InsufficientBalance` (202)
     /// - `ContractError::LockupNotExpired` (204)
     /// - `ContractError::Underflow` (701)
-    pub fn withdraw_early(e: Env, amount: i128) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn withdraw_early(e: Env, identity: Address, amount: i128) -> IdentityBond {
+        identity.require_auth();
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -555,8 +560,9 @@ impl CredenceBond {
     /// - `ContractError::BondNotFound` (200)
     /// - `ContractError::NotRollingBond` (205)
     /// - `ContractError::WithdrawalAlreadyRequested` (206)
-    pub fn request_withdrawal(e: Env) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn request_withdrawal(e: Env, identity: Address) -> IdentityBond {
+        identity.require_auth();
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -582,8 +588,8 @@ impl CredenceBond {
     ///
     /// Errors:
     /// - `ContractError::BondNotFound` (200)
-    pub fn renew_if_rolling(e: Env) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn renew_if_rolling(e: Env, identity: Address) -> IdentityBond {
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -611,8 +617,8 @@ impl CredenceBond {
     }
 
     /// Get current tier for the bond's bonded amount.
-    pub fn get_tier(e: Env) -> BondTier {
-        let bond = Self::get_identity_state(e);
+    pub fn get_tier(e: Env, identity: Address) -> BondTier {
+        let bond = Self::get_identity_state(e, identity);
         tiered_bond::get_tier_for_amount(bond.bonded_amount)
     }
 
@@ -632,8 +638,8 @@ impl CredenceBond {
     ///
     /// # Events
     /// Emits `bond_slashed` event with (identity, slash_amount, total_slashed_amount)
-    pub fn slash(e: Env, admin: Address, amount: i128) -> IdentityBond {
-        slashing::slash_bond(&e, &admin, amount)
+    pub fn slash(e: Env, admin: Address, identity: Address, amount: i128) -> IdentityBond {
+        slashing::slash_bond(&e, &admin, &identity, amount)
     }
 
     /// Top up the bond with additional amount (checks for overflow)
@@ -641,8 +647,8 @@ impl CredenceBond {
     /// Errors:
     /// - `ContractError::BondNotFound` (200)
     /// - `ContractError::Overflow` (700)
-    pub fn top_up(e: Env, amount: i128) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn top_up(e: Env, identity: Address, amount: i128) -> IdentityBond {
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -665,8 +671,8 @@ impl CredenceBond {
     /// Errors:
     /// - `ContractError::BondNotFound` (200)
     /// - `ContractError::Overflow` (700)
-    pub fn extend_duration(e: Env, additional_duration: u64) -> IdentityBond {
-        let key = DataKey::Bond;
+    pub fn extend_duration(e: Env, identity: Address, additional_duration: u64) -> IdentityBond {
+        let key = DataKey::Bond(identity);
         let mut bond = e
             .storage()
             .instance()
@@ -710,7 +716,7 @@ impl CredenceBond {
         identity.require_auth();
         Self::acquire_lock(&e);
 
-        let bond_key = DataKey::Bond;
+        let bond_key = DataKey::Bond(identity.clone());
         let bond: IdentityBond = e
             .storage()
             .instance()
@@ -787,7 +793,7 @@ impl CredenceBond {
     /// - `ContractError::BondNotFound` (200)
     /// - `ContractError::BondNotActive` (201)
     /// - `ContractError::SlashExceedsBond` (203)
-    pub fn slash_bond(e: Env, admin: Address, slash_amount: i128) -> i128 {
+    pub fn slash_bond(e: Env, admin: Address, identity: Address, slash_amount: i128) -> i128 {
         admin.require_auth();
         Self::acquire_lock(&e);
 
@@ -801,7 +807,7 @@ impl CredenceBond {
             panic_with_error!(e, ContractError::NotAdmin);
         }
 
-        let bond_key = DataKey::Bond;
+        let bond_key = DataKey::Bond(identity.clone());
         let bond: IdentityBond = e
             .storage()
             .instance()

--- a/test.rs
+++ b/test.rs
@@ -44,11 +44,11 @@ fn test_ttl_bumps_on_reads_keep_entry_alive() {
 
     // Advance to just below the TTL threshold and read to bump again
     advance_with_max_ttl(&env, STORAGE_TTL_EXTEND_TO - 1, STORAGE_TTL_EXTEND_TO);
-    let _ = client.get_identity_state();
+    let _ = client.get_identity_state(&owner);
 
     // Advance again close to the TTL and ensure read still succeeds
     advance_with_max_ttl(&env, STORAGE_TTL_EXTEND_TO - 1, STORAGE_TTL_EXTEND_TO);
-    let _ = client.get_identity_state();
+    let _ = client.get_identity_state(&owner);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_bond_locked_for_max_duration_never_expires_before_unlock() {
 
     // Advance to bond end (just before unlock) and ensure bond still present
     advance_with_max_ttl(&env, max_duration - 1, STORAGE_TTL_EXTEND_TO);
-    let _ = client.get_identity_state();
+    let _ = client.get_identity_state(&owner);
 
     // Advance to unlock time and attempt withdraw_bond (owner must be able to withdraw)
     advance_with_max_ttl(&env, 2, STORAGE_TTL_EXTEND_TO);
@@ -121,14 +121,15 @@ fn test_not_initialized_errors() {
 fn test_bond_not_found_and_insufficient_balance() {
     let (env, _admin, client) = setup();
 
+    let owner = Address::generate(&env);
+
     // No bond exists yet
-    let err = client.try_get_identity_state().unwrap_err().unwrap();
+    let err = client.try_get_identity_state(&owner).unwrap_err().unwrap();
     assert_eq!(err, ContractError::BondNotFound);
 
     // Create a small bond and attempt to withdraw more than available
-    let owner = Address::generate(&env);
     let _bond = client.create_bond(&owner, &100_i128, &1000_u64);
-    let err2 = client.try_withdraw(&200_i128).unwrap_err().unwrap();
+    let err2 = client.try_withdraw(&owner, &200_i128).unwrap_err().unwrap();
     assert_eq!(err2, ContractError::InsufficientBalance);
 }
 
@@ -139,12 +140,12 @@ fn test_request_withdrawal_not_rolling_and_already_requested() {
 
     // Non-rolling bond -> NotRollingBond
     let _bond = client.create_bond(&owner, &100_i128, &1000_u64);
-    let err = client.try_request_withdrawal().unwrap_err().unwrap();
+    let err = client.try_request_withdrawal(&owner).unwrap_err().unwrap();
     assert_eq!(err, ContractError::NotRollingBond);
 
     // Rolling bond: first request succeeds, second fails with WithdrawalAlreadyRequested
     let _rb = client.create_bond_with_rolling(&owner, &100_i128, &1000_u64, &true, &10_u64);
-    let _ = client.request_withdrawal();
-    let err2 = client.try_request_withdrawal().unwrap_err().unwrap();
+    let _ = client.request_withdrawal(&owner);
+    let err2 = client.try_request_withdrawal(&owner).unwrap_err().unwrap();
     assert_eq!(err2, ContractError::WithdrawalAlreadyRequested);
 }

--- a/test_slash_bond.rs
+++ b/test_slash_bond.rs
@@ -33,22 +33,22 @@ fn last_bond_slashed_event(e: &Env) -> (Address, i128, i128) {
 
 #[test]
 fn slash_bond_rejects_negative_amount() {
-    let (_, client, admin, _) = setup();
+    let (_, client, admin, identity) = setup();
 
-    assert!(client.try_slash_bond(&admin, &-1_i128).is_err());
+    assert!(client.try_slash_bond(&admin, &identity, &-1_i128).is_err());
 
-    let bond = client.get_identity_state();
+    let bond = client.get_identity_state(&identity);
     assert_eq!(bond.slashed_amount, 0);
     assert!(!client.is_locked());
 }
 
 #[test]
 fn slash_bond_rejects_zero_amount() {
-    let (_, client, admin, _) = setup();
+    let (_, client, admin, identity) = setup();
 
-    assert!(client.try_slash_bond(&admin, &0_i128).is_err());
+    assert!(client.try_slash_bond(&admin, &identity, &0_i128).is_err());
 
-    let bond = client.get_identity_state();
+    let bond = client.get_identity_state(&identity);
     assert_eq!(bond.slashed_amount, 0);
     assert!(!client.is_locked());
 }
@@ -57,10 +57,10 @@ fn slash_bond_rejects_zero_amount() {
 fn slash_bond_emits_canonical_event_payload() {
     let (e, client, admin, identity) = setup();
 
-    let total_slashed = client.slash_bond(&admin, &250_i128);
+    let total_slashed = client.slash_bond(&admin, &identity, &250_i128);
 
     assert_eq!(total_slashed, 250);
-    assert_eq!(client.get_identity_state().slashed_amount, 250);
+    assert_eq!(client.get_identity_state(&identity).slashed_amount, 250);
     assert_eq!(last_bond_slashed_event(&e), (identity, 250, 250));
 }
 
@@ -68,38 +68,38 @@ fn slash_bond_emits_canonical_event_payload() {
 fn slash_bond_allows_exact_cap() {
     let (e, client, admin, identity) = setup();
 
-    let total_slashed = client.slash_bond(&admin, &AMOUNT);
+    let total_slashed = client.slash_bond(&admin, &identity, &AMOUNT);
 
     assert_eq!(total_slashed, AMOUNT);
-    assert_eq!(client.get_identity_state().slashed_amount, AMOUNT);
+    assert_eq!(client.get_identity_state(&identity).slashed_amount, AMOUNT);
     assert_eq!(last_bond_slashed_event(&e), (identity, AMOUNT, AMOUNT));
 }
 
 #[test]
 fn slash_bond_rejects_over_cap_and_preserves_state() {
-    let (_, client, admin, _) = setup();
-    client.slash_bond(&admin, &750_i128);
+    let (_, client, admin, identity) = setup();
+    client.slash_bond(&admin, &identity, &750_i128);
 
-    assert!(client.try_slash_bond(&admin, &251_i128).is_err());
+    assert!(client.try_slash_bond(&admin, &identity, &251_i128).is_err());
 
-    let bond = client.get_identity_state();
+    let bond = client.get_identity_state(&identity);
     assert_eq!(bond.slashed_amount, 750);
     assert!(!client.is_locked());
 }
 
 #[test]
 fn slash_bond_keeps_slashed_amount_monotonic_and_bounded() {
-    let (_, client, admin, _) = setup();
+    let (_, client, admin, identity) = setup();
 
-    let first = client.slash_bond(&admin, &100_i128);
-    let second = client.slash_bond(&admin, &300_i128);
-    let third = client.slash_bond(&admin, &600_i128);
+    let first = client.slash_bond(&admin, &identity, &100_i128);
+    let second = client.slash_bond(&admin, &identity, &300_i128);
+    let third = client.slash_bond(&admin, &identity, &600_i128);
 
     assert_eq!(first, 100);
     assert_eq!(second, 400);
     assert_eq!(third, AMOUNT);
 
-    let bond = client.get_identity_state();
+    let bond = client.get_identity_state(&identity);
     assert_eq!(bond.slashed_amount, AMOUNT);
     assert!(bond.slashed_amount <= bond.bonded_amount);
 }


### PR DESCRIPTION
This PR refactors the core storage layer of the credence_bond smart contract to support multiple independent identity bonds per deployed contract instance. Previously, the contract utilized a monolithic DataKey::Bond instance slot that only permitted one global bond configuration. This limitation caused subsequent calls to create_bond to overwrite prior data, creating a severe vulnerability where accounting was wiped and escrowed funds could be stranded.

By transitioning the storage schema to a per-identity persistent mapping (DataKey::Bond(Address)), the contract can now securely isolate state variables, thresholds, and life cycles for an arbitrary number of distinct identities.

Closes #354 