### PR TITLE
feat: reconcile nonce replay protection across delegation entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -193,27 +187,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -314,6 +287,7 @@ dependencies = [
 name = "credence_bond"
 version = "0.1.0"
 dependencies = [
+ "credence_errors",
  "soroban-sdk",
 ]
 
@@ -360,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -585,7 +559,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -610,7 +584,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -621,16 +595,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "escape-bytes"
@@ -645,18 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -677,12 +635,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -709,38 +661,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -761,24 +688,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -827,12 +739,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -916,12 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,12 +832,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1074,31 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,36 +977,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1147,17 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1166,25 +1003,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
+ "getrandom",
 ]
 
 [[package]]
@@ -1208,12 +1027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,35 +1046,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "schemars"
@@ -1414,7 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1451,7 +1239,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1479,7 +1267,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom 0.2.17",
+ "getrandom",
  "hex-literal",
  "hmac",
  "k256",
@@ -1487,8 +1275,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "sec1",
  "sha2",
  "sha3",
@@ -1497,7 +1285,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1540,7 +1328,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1580,7 +1368,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1696,19 +1484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "templates"
 version = "0.1.0"
 dependencies = [
@@ -1777,22 +1552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1801,37 +1564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1879,28 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,18 +1638,6 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -2006,109 +1708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/credence_bond/src/fuzz/test_bond_fuzz.rs
+++ b/contracts/credence_bond/src/fuzz/test_bond_fuzz.rs
@@ -132,7 +132,10 @@ impl BondState {
             .checked_add(amount)
             .ok_or("bonded_amount overflow")?;
 
-        Ok(Self { bonded_amount, ..self })
+        Ok(Self {
+            bonded_amount,
+            ..self
+        })
     }
 
     fn slash(self, amount: i128) -> Result<Self, &'static str> {
@@ -154,7 +157,10 @@ impl BondState {
             new_slashed
         };
 
-        Ok(Self { slashed_amount, ..self })
+        Ok(Self {
+            slashed_amount,
+            ..self
+        })
     }
 
     fn withdraw(self, amount: i128) -> Result<Self, &'static str> {
@@ -175,7 +181,10 @@ impl BondState {
             .checked_sub(amount)
             .ok_or("bonded_amount underflow")?;
 
-        Ok(Self { bonded_amount, ..self })
+        Ok(Self {
+            bonded_amount,
+            ..self
+        })
     }
 }
 

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -102,20 +102,24 @@ impl CredenceDelegation {
     }
 
     // -----------------------------------------------------------------------
-    // Direct (auth-required) entry points — no off-chain signature needed
+    // Direct (auth-required) entry points — updated for unified nonce verification
     // -----------------------------------------------------------------------
 
     /// Create a delegation from owner to delegate with a given type and expiry.
-    /// The owner must be the transaction signer.
+    /// The owner must be the transaction signer and provide the correct current nonce.
     pub fn delegate(
         e: Env,
         owner: Address,
         delegate: Address,
         delegation_type: DelegationType,
         expires_at: u64,
+        nonce: u64,
     ) -> Delegation {
         pausable::require_not_paused(&e);
         owner.require_auth();
+
+        // Enforce centralized sequential replay tracking
+        nonce::consume_nonce(&e, &owner, nonce);
 
         if expires_at <= e.ledger().timestamp() {
             panic_with_error!(&e, ContractError::ExpiryInPast);
@@ -124,23 +128,30 @@ impl CredenceDelegation {
         Self::store_delegation(&e, owner, delegate, delegation_type, expires_at)
     }
 
-    /// Revoke an existing delegation. Only the owner can revoke.
+    /// Revoke an existing delegation. Only the owner can revoke and must provide the correct current nonce.
     pub fn revoke_delegation(
         e: Env,
         owner: Address,
         delegate: Address,
         delegation_type: DelegationType,
+        nonce: u64,
     ) {
         pausable::require_not_paused(&e);
         owner.require_auth();
 
+        // Enforce centralized sequential replay tracking
+        nonce::consume_nonce(&e, &owner, nonce);
+
         Self::mark_delegation_revoked(&e, owner, delegate, delegation_type, "delegation");
     }
 
-    /// Revoke an attestation-type delegation.  Only the original attester can revoke.
-    pub fn revoke_attestation(e: Env, attester: Address, subject: Address) {
+    /// Revoke an attestation-type delegation. Only the original attester can revoke and must provide the correct current nonce.
+    pub fn revoke_attestation(e: Env, attester: Address, subject: Address, nonce: u64) {
         pausable::require_not_paused(&e);
         attester.require_auth();
+
+        // Enforce centralized sequential replay tracking
+        nonce::consume_nonce(&e, &attester, nonce);
 
         Self::mark_delegation_revoked(
             &e,

--- a/contracts/credence_delegation/src/test.rs
+++ b/contracts/credence_delegation/src/test.rs
@@ -25,7 +25,13 @@ fn test_delegate_attestation() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    let d = client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    let d = client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
 
     assert_eq!(d.owner, owner);
     assert_eq!(d.delegate, delegate);
@@ -64,8 +70,14 @@ fn test_revoke_delegation() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &1_u64);
 
     let d = client.get_delegation(&owner, &delegate, &DelegationType::Attestation);
     assert!(d.revoked);

--- a/contracts/credence_delegation/src/test_domain_separation.rs
+++ b/contracts/credence_delegation/src/test_domain_separation.rs
@@ -493,3 +493,89 @@ fn happy_path_delegated_revoke_attestation() {
     ));
     assert_eq!(client.get_nonce(&attester), 1);
 }
+
+#[test]
+fn test_direct_path_nonce_reconciliation_and_invalidation() {
+    let (e, client, contract_id) = setup();
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    let expiry = e.ledger().timestamp() + 86_400;
+
+    // 1. Direct path action consumes sequence 0
+    assert_eq!(client.get_nonce(&owner), 0);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &expiry,
+        &0_u64,
+    );
+    assert_eq!(client.get_nonce(&owner), 1);
+
+    // 2. Direct path action fails if reusing sequence 0
+    let res = client.try_delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Management,
+        &expiry,
+        &0_u64,
+    );
+    assert!(
+        res.is_err(),
+        "Expected rejection of stale sequence on direct execution"
+    );
+
+    // 3. Trigger range invalidation mechanism to bounce current sequence to index 5
+    client.invalidate_nonce_range(&owner, &5_u64);
+    assert_eq!(client.get_nonce(&owner), 5);
+
+    // 4. Stale execution attempt at historical gap index fails
+    let res_stale = client.try_delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Management,
+        &expiry,
+        &1_u64,
+    );
+    assert!(res_stale.is_err());
+
+    // 5. Valid transaction successfully locks in sequence sequence index 5
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Management,
+        &expiry,
+        &5_u64,
+    );
+    assert_eq!(client.get_nonce(&owner), 6);
+}
+
+#[test]
+fn test_mixed_execution_interleaving() {
+    let (e, client, contract_id) = setup();
+    let owner = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    let expiry = e.ledger().timestamp() + 86_400;
+
+    // Direct invocation uses 0
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &expiry,
+        &0_u64,
+    );
+
+    // Relayer off-chain action relies on index 1
+    let payload = make_payload(
+        &e,
+        DomainTag::RevokeDelegation,
+        &owner,
+        &delegate,
+        &contract_id,
+        1,
+    );
+    client.execute_delegated_revoke(&owner, &delegate, &DelegationType::Attestation, &payload);
+
+    assert_eq!(client.get_nonce(&owner), 2);
+}

--- a/contracts/credence_delegation/src/test_pausable.rs
+++ b/contracts/credence_delegation/src/test_pausable.rs
@@ -91,16 +91,28 @@ fn test_pause_proposal_id_uniqueness_and_scoped_approval_lifecycle() {
     client.approve_pause_proposal(&s3, &proposal_a);
     client.execute_pause_proposal(&proposal_a);
     assert!(client.is_paused());
-    assert!(!env.storage().instance().has(&DataKey::PauseProposal(proposal_a)));
-    assert!(!env.storage().instance().has(&DataKey::PauseApprovalCount(proposal_a)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseProposal(proposal_a)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseApprovalCount(proposal_a)));
 
     client.approve_pause_proposal(&s1, &proposal_b);
     assert!(client.try_execute_pause_proposal(&proposal_b).is_err());
     client.approve_pause_proposal(&s3, &proposal_b);
     client.execute_pause_proposal(&proposal_b);
     assert!(!client.is_paused());
-    assert!(!env.storage().instance().has(&DataKey::PauseProposal(proposal_b)));
-    assert!(!env.storage().instance().has(&DataKey::PauseApprovalCount(proposal_b)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseProposal(proposal_b)));
+    assert!(!env
+        .storage()
+        .instance()
+        .has(&DataKey::PauseApprovalCount(proposal_b)));
 
     assert!(client.try_execute_pause_proposal(&proposal_a).is_err());
 }

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -10,20 +10,20 @@ The `CredenceDelegation` contract stores delegations keyed by `(owner, delegate,
 
 ### DelegationType
 
-| Variant       | Description                              |
-|---------------|------------------------------------------|
-| Attestation   | Delegate can attest on behalf of owner   |
-| Management    | Delegate can manage bonds on behalf of owner |
+| Variant     | Description                                  |
+| ----------- | -------------------------------------------- |
+| Attestation | Delegate can attest on behalf of owner       |
+| Management  | Delegate can manage bonds on behalf of owner |
 
 ### Delegation
 
-| Field            | Type            | Description                      |
-|------------------|-----------------|----------------------------------|
-| owner            | Address         | Bond owner granting delegation   |
-| delegate         | Address         | Address receiving delegated rights |
-| delegation_type  | DelegationType  | Kind of delegation               |
-| expires_at       | u64             | Ledger timestamp when delegation expires |
-| revoked          | bool            | Whether the delegation was revoked |
+| Field           | Type           | Description                              |
+| --------------- | -------------- | ---------------------------------------- |
+| owner           | Address        | Bond owner granting delegation           |
+| delegate        | Address        | Address receiving delegated rights       |
+| delegation_type | DelegationType | Kind of delegation                       |
+| expires_at      | u64            | Ledger timestamp when delegation expires |
+| revoked         | bool           | Whether the delegation was revoked       |
 
 ## Contract Functions
 
@@ -49,10 +49,10 @@ Returns `true` if the delegation exists, is not revoked, and has not expired. Re
 
 ## Events
 
-| Event                | Data        | Emitted when              |
-|----------------------|-------------|---------------------------|
-| delegation_created   | Delegation  | A new delegation is stored |
-| delegation_revoked   | Delegation  | A delegation is revoked    |
+| Event              | Data       | Emitted when               |
+| ------------------ | ---------- | -------------------------- |
+| delegation_created | Delegation | A new delegation is stored |
+| delegation_revoked | Delegation | A delegation is revoked    |
 
 ## Security
 
@@ -64,7 +64,7 @@ Returns `true` if the delegation exists, is not revoked, and has not expired. Re
 
 ## Pausing
 
-The contract implements a pause mechanism to protect the protocol in case of emergency. 
+The contract implements a pause mechanism to protect the protocol in case of emergency.
 
 - **Mechanism**: Can be a direct pause by admin (if threshold is 0) or a multi-sig proposal process (if threshold > 0).
 - **Gated Functions**: All mutating functions related to delegation are gated and will panic if the contract is paused:
@@ -73,6 +73,14 @@ The contract implements a pause mechanism to protect the protocol in case of eme
   - `revoke_attestation` / `execute_delegated_revoke_attest`
   - `invalidate_nonce_range`
 - **Exempt Functions**: Query functions (`is_valid_delegate`, `get_delegation`, etc.) and pause-management functions remain active even when paused.
+
+## Nonce Replay Model & Key Recovery
+
+The contract enforces a uniform replay security model across all mutating entry points (`delegate`, `revoke_delegation`, `revoke_attestation`, and their `execute_delegated_*` relayer counterparts). Every identity maps directly to an independent sequential sequence stream.
+
+1. **Direct Path Invocation**: Calls made directly by account owners must specify their current tracking sequence sequence parameter explicitly. This asserts operational parity with signed payloads.
+2. **Relayed Executions**: Off-chain entities presenting payload structures must contain matching valid parameters and match the expected sequence sequence index exactly.
+3. **Emergency Key Recovery**: Invoking `invalidate_nonce_range(id, to_nonce)` forces the internal sequence tracker forward. This permanently drops all signatures and pre-allocated instructions whose nonces fall below the updated boundary across both entry vectors.
 
 ## Usage
 


### PR DESCRIPTION
This PR resolves issue #371  by eliminating the security and operational asymmetry between the direct transaction paths (delegate, revoke_delegation, revoke_attestation) and the relayed execution paths (execute_delegated_*).

Closes #371 