### PR TITLE
Fix/ci repducibility check

### DIFF
--- a/.github/workflows/wasm-repro.yml
+++ b/.github/workflows/wasm-repro.yml
@@ -1,0 +1,73 @@
+name: Wasm Reproducibility
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - ci/**
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - contracts/**
+      - .github/workflows/wasm-repro.yml
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - contracts/**
+      - .github/workflows/wasm-repro.yml
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  LC_ALL: C.UTF-8
+  LANG: C.UTF-8
+  TZ: UTC
+  SOURCE_DATE_EPOCH: "0"
+
+jobs:
+  reproducibility:
+    name: Reproducible wasm builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-wasm-repro-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-repro-
+
+      - name: Build and hash pass 1
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/wasm-repro-1
+        run: |
+          cargo build --release --target wasm32-unknown-unknown --locked -p credence_bond -p credence_delegation
+          sha256sum "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_bond.wasm" \
+            "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_delegation.wasm" \
+            > "$RUNNER_TEMP/wasm-repro-1.sha256"
+
+      - name: Build and hash pass 2
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/wasm-repro-2
+        run: |
+          cargo build --release --target wasm32-unknown-unknown --locked -p credence_bond -p credence_delegation
+          sha256sum "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_bond.wasm" \
+            "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_delegation.wasm" \
+            > "$RUNNER_TEMP/wasm-repro-2.sha256"
+
+      - name: Compare hashes
+        run: diff -u "$RUNNER_TEMP/wasm-repro-1.sha256" "$RUNNER_TEMP/wasm-repro-2.sha256"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Part of [Credence](../README.md). Contracts run on the Stellar network via Sorob
 
 ## Prerequisites
 
-- Rust 1.84+ (with `wasm32-unknown-unknown`: `rustup target add wasm32-unknown-unknown`)
+- Rust 1.85.1+ (pinned in [`rust-toolchain.toml`](rust-toolchain.toml)); the WASM target is included
 - [Soroban CLI](https://developers.stellar.org/docs/smart-contracts/getting-started/setup) (`cargo install soroban-cli`)
 
 ## Setup
@@ -23,8 +23,10 @@ cargo build
 For Soroban (WASM) build:
 
 ```bash
-cargo build --target wasm32-unknown-unknown --release -p credence_bond
+cargo build --target wasm32-unknown-unknown --release --locked -p credence_bond -p credence_delegation
 ```
+
+For the reproducibility check and the CI hash comparison, see [docs/wasm-reproducibility.md](docs/wasm-reproducibility.md).
 
 ## Tests
 

--- a/docs/wasm-reproducibility.md
+++ b/docs/wasm-reproducibility.md
@@ -1,0 +1,44 @@
+# WASM Reproducibility
+
+Credence treats Soroban WASM output as a supply-chain artifact. The goal is that a clean build of the bond and delegation contracts produces the same bytes every time when the source, lockfile, and toolchain are unchanged.
+
+## What CI checks
+
+The workflow at [`.github/workflows/wasm-repro.yml`](../.github/workflows/wasm-repro.yml) performs two clean builds with `--locked` and compares SHA-256 digests for:
+
+- `target/wasm32-unknown-unknown/release/credence_bond.wasm`
+- `target/wasm32-unknown-unknown/release/credence_delegation.wasm`
+
+If either hash differs between the two passes, the workflow fails immediately.
+
+## Toolchain pin
+
+The repository pins Rust in [`rust-toolchain.toml`](../rust-toolchain.toml) to keep CI and local builds on the same compiler and target set:
+
+- `channel = "1.85.1"`
+- `targets = ["wasm32-unknown-unknown"]`
+- `components = ["rustfmt", "clippy", "llvm-tools-preview"]`
+
+That pin is the first line of defense against drift from a moving `stable` toolchain.
+
+## Local reproduction
+
+Run the same build twice from a clean working tree:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown --locked -p credence_bond -p credence_delegation
+sha256sum target/wasm32-unknown-unknown/release/credence_bond.wasm \
+  target/wasm32-unknown-unknown/release/credence_delegation.wasm
+```
+
+Then clean the target directory, rebuild, and compare the digests. A passing CI run ends with the hash comparison step succeeding and no diff output.
+
+## Security notes
+
+- A hash mismatch is treated as a build-integrity failure, not a warning.
+- The check is designed to catch accidental nondeterminism and build-time injection before deployment.
+- Use the pinned toolchain and `--locked` builds when validating contract changes locally.
+
+## CI output shape
+
+A successful run should show the two build passes completing and the final diff step exiting cleanly. A failure should surface a mismatched digest for one or both WASM artifacts and stop the merge.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.1"
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Closes #416

---

PR: Enforce deterministic WASM builds for bond and delegation (Issue #416)

Summary
-------
This change adds a CI reproducibility check that ensures Soroban WASM artifacts are byte-identical across two clean, locked builds. It also pins the Rust toolchain used for builds, documents the reproducibility process, and updates the README to instruct locked builds for WASM artifacts.

Why
---
Verifiable deployments require that compiled WASM artifacts are reproducible. Checking in `Cargo.lock` alone does not prevent build-time nondeterminism or toolchain drift that could alter WASM bytes. The CI job fails fast if a mismatch is detected, protecting against accidental nondeterminism and build-time injection.

What I changed
-------------
- Added a reproducibility GitHub Actions workflow: `.github/workflows/wasm-repro.yml`
  - Runs two clean `cargo build --release --target wasm32-unknown-unknown --locked` passes
  - Hashes `credence_bond.wasm` and `credence_delegation.wasm` from each pass and fails if any SHA-256 differs
- Pinned Rust toolchain: `rust-toolchain.toml` (set to `1.85.1`, includes `wasm32-unknown-unknown`, `rustfmt`, `clippy`, `llvm-tools-preview`)
- Documentation: `docs/wasm-reproducibility.md` explaining CI behavior, local reproduction steps, security notes
- README updated to recommend `--locked` builds for WASM and link to the new doc

Files added / updated
--------------------
- Added: `rust-toolchain.toml`
- Added: `.github/workflows/wasm-repro.yml`
- Added: `docs/wasm-reproducibility.md`
- Updated: `README.md`

Branch
------
fix/ci-reproducibility-check

How it works (short)
--------------------
1. Checkout repository in CI
2. Use pinned toolchain (rust-toolchain.toml)
3. Build packages `credence_bond` and `credence_delegation` with `--locked` into an isolated `CARGO_TARGET_DIR`
4. Compute `sha256sum` of each WASM artifact for pass 1 and pass 2
5. Run `diff -u` on the two digest files; non-zero exit fails CI

Local validation steps
----------------------
Run the same commands locally to reproduce a CI failure:

```bash
# Ensure pinned toolchain is installed
rustup toolchain install 1.85.1
rustup default 1.85.1
rustup target add wasm32-unknown-unknown

# Build pass 1
CARGO_TARGET_DIR=$(mktemp -d)/wasm-repro-1
cargo build --release --target wasm32-unknown-unknown --locked -p credence_bond -p credence_delegation --target-dir "$CARGO_TARGET_DIR"
sha256sum "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_bond.wasm" \
  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_delegation.wasm" > /tmp/wasm-repro-1.sha256

# Clean, build pass 2
CARGO_TARGET_DIR=$(mktemp -d)/wasm-repro-2
cargo build --release --target wasm32-unknown-unknown --locked -p credence_bond -p credence_delegation --target-dir "$CARGO_TARGET_DIR"
sha256sum "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_bond.wasm" \
  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/credence_delegation.wasm" > /tmp/wasm-repro-2.sha256

# Compare
diff -u /tmp/wasm-repro-1.sha256 /tmp/wasm-repro-2.sha256
```

Note: On Windows use appropriate shell commands for temp directories and `sha256sum` (e.g., `Get-FileHash -Algorithm SHA256`).

Validation performed here
------------------------
- Added the job and docs in this branch.
- Ran `cargo test --workspace --locked` locally in the environment used for this work; initial run failed due to a crate requiring `edition2024` while the pinned toolchain was `1.84.0`. I bumped the pin to `1.85.1` to resolve the manifest incompatibility. The full workspace test ran successfully.
-----------------------------------------------
```
Security notes
--------------
- Failing the CI job on hash mismatch prevents merging a PR that produces nondeterministic artifacts.
- The pinned toolchain reduces drift from `stable` updates and helps keep CI and local builds consistent.
- The job uses `--locked` to ensure dependency resolution is tied to `Cargo.lock`.