### PR TITLE
ci(contracts): enforce per-crate wasm size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,9 @@ jobs:
 
       - name: Build release (workspace)
         run: cargo build --release
+
+      - name: Install wasm-tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y wabt
+      - name: Check wasm size budget
+        run: bash scripts/check_wasm_size.sh

--- a/docs/wasm-size-budget.md
+++ b/docs/wasm-size-budget.md
@@ -1,0 +1,26 @@
+# Wasm Size Budget
+
+Soroban contracts have a hard on‑chain size limit of ~64 KB per contract Wasm. Exceeding this limit prevents upgrades and can cause runtime failures.
+
+## Enforced Limit
+- Default ceiling: **64 KB** (65 536 bytes).
+- The limit can be overridden by passing a different value to the script, e.g. `./scripts/check_wasm_size.sh 60` for a 60 KB ceiling.
+
+## How It Works
+1. The CI workflow runs `scripts/check_wasm_size.sh` after building all contracts in release mode.
+2. The script scans `target/wasm32-unknown-unknown/release/*.wasm` and fails the job if any artifact exceeds the configured ceiling.
+3. Debug symbols are stripped via the workspace `profile.release.strip = "symbols"` setting, ensuring only the actual code size is measured.
+
+## Local Validation
+Developers can run the check locally:
+```bash
+chmod +x scripts/check_wasm_size.sh
+./scripts/check_wasm_size.sh 64
+```
+The script will output pass/fail messages for each contract.
+
+## Adjusting the Budget
+If a particular contract legitimately needs more space, adjust the limit in the CI step or modify the script invocation accordingly.
+
+---
+*This document was added as part of the `feature/wasm-size-budget` implementation.*

--- a/scripts/check_wasm_size.sh
+++ b/scripts/check_wasm_size.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# check_wasm_size.sh - verify each contract wasm file is under size limit (default 64KB)
+set -euo pipefail
+MAX_KB=${1:-64}
+MAX_BYTES=$((MAX_KB * 1024))
+echo "Checking wasm size limit: ${MAX_KB}KB (${MAX_BYTES} bytes)"
+# Find all wasm files in target directory for workspace contracts
+shopt -s nullglob
+easy_wasm_files=(target/wasm32-unknown-unknown/release/*.wasm)
+if [ ${#easy_wasm_files[@]} -eq 0 ]; then
+  echo "[ERROR] No wasm files found in target/wasm32-unknown-unknown/release/"
+  exit 1
+fi
+for wasm in "${easy_wasm_files[@]}"; do
+  size=$(wc -c < "$wasm")
+  if (( size > MAX_BYTES )); then
+    echo "[FAIL] $wasm size $(($size/1024))KB exceeds limit of ${MAX_KB}KB"
+    exit 1
+  else
+    echo "[PASS] $wasm size $(($size/1024))KB within limit"
+  fi
+done
+exit 0


### PR DESCRIPTION
this pr closes #432 

 Summary
Adds a safeguard to ensure every Soroban contract’s compiled Wasm binary stays under the on‑chain size limit (~64 KB). The changes include:

- **`scripts/check_wasm_size.sh`** – Bash script that scans `target/wasm32-unknown-unknown/release/*.wasm` and fails when any file exceeds the configurable ceiling (default 64 KB).  
- **CI integration** – `.github/workflows/ci.yml` now installs `wabt` and runs the size‑check script after the release build, causing the workflow to fail if a contract is too large.  
- **Documentation** – `docs/wasm-size-budget.md` explains the budget, how to adjust it, and how to run the check locally.  
- **Test stub** – `credence_bond/src/dummy_large.rs` (~5 KB of dead code) added to verify that the CI step correctly aborts when the limit is breached.

### Files Added
| Path | Purpose |
|------|----------|
| `scripts/check_wasm_size.sh` | Size‑validation script |
| `docs/wasm-size-budget.md`   | Design‑time documentation |
| `credence_bond/src/dummy_large.rs` | Dummy code for validation |

### Files Modified
| Path | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `wabt` installation and a step that runs `bash scripts/check_wasm_size.sh` after building release artifacts |

### How It Works
1. **Build** – CI builds all contracts in release mode targeting `wasm32‑unknown‑unknown`.  
2. **Check** – The new step runs `bash scripts/check_wasm_size.sh`.  
   - **Pass:** every `.wasm` ≤ 64 KB (or supplied limit).  
   - **Fail:** any contract exceeds the limit → step exits 1, CI job fails.  
3. **Local usage** – Developers can run `./scripts/check_wasm_size.sh [KB]` locally to validate size before pushing.

### Adjusting the Budget
Edit the `MAX_KB` variable in the script or invoke it with a different value, e.g.:

```bash
bash scripts/check_wasm_size.sh 70   # set a 70 KB ceiling
```

### Impact
- **Prevents** accidental upgrades that would be rejected by Soroban nodes due to oversized Wasm binaries.  
- **Provides early feedback** in CI, saving time and avoiding post‑merge rollbacks.  
- **Documents** the size constraint for future contributors.

### Verification
The dummy `dummy_large.rs` purposely pushes a contract over the limit; a CI run should fail, confirming the guard works. After the PR is merged, remove the dummy file.

---  

Please review, ensure CI passes after removing the dummy file, and merge when