### PR TITLE
feat(delegation): replay-window proof and property tests for invalida…

### DIFF
--- a/contracts/credence_delegation/Cargo.toml
+++ b/contracts/credence_delegation/Cargo.toml
@@ -5,8 +5,11 @@ edition = "2021"
 description = "Credence delegation contract — delegate attestation and management rights"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "22.0", features = ["testutils"] }
 credence_errors = { path = "../credence_errors" }
+
+[dev-dependencies]
+proptest = { version = "1", default-features = false, features = ["std"] }

--- a/contracts/credence_delegation/docs/nonce-replay-proof.md
+++ b/contracts/credence_delegation/docs/nonce-replay-proof.md
@@ -1,0 +1,215 @@
+# Nonce Replay-Window Proof
+
+## Overview
+
+This document proves that `nonce::invalidate_nonce_range` in the Credence
+delegation contract permanently invalidates all payloads whose nonce falls
+inside the specified half-open range, and demonstrates the threat model
+assumptions under which the proof holds.
+
+---
+
+## Background: The Nonce System
+
+The delegation contract maintains a **per-identity, strictly monotone nonce**
+stored in Soroban persistent storage under `DataKey::Nonce(identity)`.
+
+Every state-changing call — both the direct-auth path (`delegate`,
+`revoke_delegation`, `revoke_attestation`) and the relayed path
+(`execute_delegated_delegate`, `execute_delegated_revoke`,
+`execute_delegated_revoke_attest`) — must supply the current nonce value.
+`consume_nonce` accepts the nonce only when it exactly equals the stored
+value, then unconditionally increments the stored value by 1.
+
+```
+consume_nonce(identity, expected):
+    current ← storage[Nonce(identity)]   // default 0 if not set
+    require current == expected           // else panic InvalidNonce
+    storage[Nonce(identity)] ← current + 1
+```
+
+---
+
+## The `invalidate_nonce_range` Operation
+
+```rust
+/// MAX_NONCE_INVALIDATION_SPAN = 10_000
+pub fn invalidate_nonce_range(
+    identity: &Address,
+    new_nonce: u64,
+    max_span: u64,        // MAX_NONCE_INVALIDATION_SPAN
+) -> (current, new_nonce)
+```
+
+The operation:
+1. Reads `current = storage[Nonce(identity)]`.
+2. Rejects if `new_nonce <= current` (monotonicity guard).
+3. Rejects if `new_nonce - current > max_span` (gas-bound guard).
+4. Writes `storage[Nonce(identity)] = new_nonce`.
+
+---
+
+## Formal Proof
+
+### Definitions
+
+Let `S(t)` denote the stored nonce for `identity` at "time" `t` (i.e., after
+ledger sequence `t`).
+
+**Invariant I**: `S(t)` is strictly non-decreasing: for all `t' > t`,
+`S(t') ≥ S(t)`.
+
+*Proof of I*: `S(t)` is only written in two places:
+
+- `consume_nonce`: sets `S ← S + 1`.
+- `invalidate_nonce_range`: sets `S ← new_nonce` where `new_nonce > S`.
+
+Both writes strictly increase `S`. No write decreases it. ∎
+
+---
+
+### Main Theorem
+
+**Theorem**: Let `t*` be the ledger sequence number at which a successful call
+to `invalidate_nonce_range(identity, N)` completes (writing `S(t*) = N`).
+Then for all `t > t*` and for any payload `P` with `P.nonce < N`, any call
+that invokes `consume_nonce(identity, P.nonce)` will panic with `InvalidNonce`.
+
+**Proof**:
+
+By definition, `P.nonce < N`.
+
+By Invariant I and the fact that `S(t*) = N`:
+
+```
+∀ t > t*:  S(t) ≥ S(t*) = N > P.nonce
+```
+
+Therefore `S(t) ≠ P.nonce` for all future states.
+
+`consume_nonce` requires `expected == S(t)`. Since `P.nonce ≠ S(t)`, the
+check fails and the call panics with `InvalidNonce`. ∎
+
+**Corollary (boundary)**: The last invalidated nonce is `N - 1`.  
+Any payload with `P.nonce = N - 1` satisfies `P.nonce < N`, hence it is
+permanently rejected. Conversely, the first spendable nonce after invalidation
+is exactly `N`.
+
+---
+
+## The Half-Open Range `[current, new_nonce)`
+
+The range of invalidated nonces is:
+
+```
+{ n ∈ ℕ₀ | current ≤ n < new_nonce }
+```
+
+This is a half-open interval in the mathematical sense. It includes:
+
+- The nonce at `current` — the identity could have signed payloads at this
+  value before the invalidation call.
+- Every nonce up to and including `new_nonce - 1`.
+
+After the call, all these nonces become permanently unspendable by the theorem
+above.
+
+---
+
+## Span Cap: `MAX_NONCE_INVALIDATION_SPAN = 10_000`
+
+A single `invalidate_nonce_range` call is limited to at most 10 000 nonces.
+This bound exists to:
+
+1. **Prevent gas exhaustion** — Soroban ledger resources are bounded; an
+   unbounded skip could be used to DoS the contract in the same transaction.
+2. **Predictable fee model** — Relayers can estimate the cost of an
+   invalidation without reading contract state.
+3. **Correctness** — The cap is checked *before* the write, so a rejected call
+   leaves the stored nonce unchanged.
+
+Invalidating more than 10 000 nonces requires multiple successive calls,
+each bounded by the same cap. The security guarantee is identical: after `k`
+calls that advance from `a` to `b = a + k × 10_000`, every nonce in `[a, b)`
+is unspendable.
+
+---
+
+## Threat Model
+
+### Assumptions
+
+| Assumption | Justification |
+|---|---|
+| The Soroban ledger is honest (no storage tampering) | Soroban's Byzantine-fault-tolerant consensus |
+| `consume_nonce` is the only path to consume a nonce | Verified by code review: all state-changing entry points call `consume_nonce` |
+| Overflow of `u64` nonces is impossible in practice | At 10 000 nonces/second continuously for 58 million years |
+| `identity.require_auth()` is enforced before `invalidate_nonce_range` | Soroban's auth engine rejects unauthorised callers |
+
+### Attack Vectors Addressed
+
+**Pre-signed payload replay after key compromise**:  
+If an attacker obtains pre-signed payloads with nonces `[0, K)`, the identity
+owner calls `invalidate_nonce_range(new_nonce = K)`.  By the theorem, all `K`
+payloads are permanently invalidated.
+
+**Batch payload invalidation**:  
+An off-chain service may have queued many payloads.  The identity owner can
+skip ahead by up to `MAX_NONCE_INVALIDATION_SPAN` per call, voiding the entire
+pending queue in `⌈K / 10_000⌉` transactions.
+
+**Cross-path replay (direct ↔ relayer)**:  
+Both the direct (`delegate`, `revoke_*`) and relayed
+(`execute_delegated_*`) paths consume from the same nonce namespace.
+Invalidating the range blocks both interaction types uniformly: a pre-signed
+delegated payload and a pre-signed direct payload with the same nonce value
+are both rejected after invalidation.
+
+**Re-init / nonce reset attack**:  
+The contract panics if `initialize` is called a second time.  The storage
+`Nonce` key is never re-zeroed; `get_nonce` returns 0 only if the key is
+absent (i.e., no action has ever been taken for that identity).
+
+### Out-of-Scope Threats
+
+- **Key compromise after invalidation**: If the attacker obtains the private
+  key *after* the invalidation but the identity has not yet used nonce `N`,
+  the attacker could sign a fresh payload at nonce `N`.  The solution is to
+  rotate the identity's key, not just invalidate nonces.
+- **Side-channel attacks on the ledger nodes**: Out of scope for contract-level
+  security.
+
+---
+
+## Test Coverage
+
+The property `prop_all_invalidated_nonces_rejected` in
+`tests/nonce_replay.rs` exercises this theorem directly with **10 000
+random (current, span, offset) triples**, covering:
+
+- Every possible offset within the invalidated range for randomly chosen range
+  sizes (1 to 10 000).
+- Non-zero starting nonces (0 to 999) to test mid-stream invalidations.
+- The `prop_post_invalidation_nonce_accepted` corollary — the first
+  post-invalidation nonce must succeed.
+
+Additionally, `src/test_nonce_replay.rs` contains deterministic boundary tests:
+
+| Test | Coverage |
+|---|---|
+| `nonce_replay_span_one_rejects_only_nonce` | Span = 1 (minimum) |
+| `nonce_replay_max_span_succeeds_and_rejects_all_prior_nonces` | Span = 10 000 (maximum) |
+| `nonce_replay_over_max_span_panics` | Span = 10 001 must fail |
+| `nonce_replay_boundary_last_in_range_rejected` | `new_nonce - 1` is rejected |
+| `nonce_replay_boundary_first_after_range_accepted` | `new_nonce` is accepted |
+| `nonce_replay_double_invalidation_still_rejects_old_nonces` | Chained invalidations |
+| `nonce_replay_10k_deterministic_sweep` | 10 000-iteration deterministic PRNG sweep |
+
+---
+
+## Wire Stability
+
+`MAX_NONCE_INVALIDATION_SPAN = 10_000` is a deployment-time constant, not
+stored on-chain. Changing it after deployment would affect only future calls;
+all previously invalidated ranges remain permanently invalidated because the
+stored nonce value is immutable once written.

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -86,6 +86,22 @@ enum DataKey {
 #[contract]
 pub struct CredenceDelegation;
 
+/// Maximum number of nonces that a single `invalidate_nonce_range` call may
+/// skip.  Bounding the span prevents gas-exhaustion and ensures the nonce
+/// stream advances at a predictable pace.
+///
+/// **Replay-window proof (informal):**
+/// After `invalidate_nonce_range(identity, new_nonce)` succeeds, the stored
+/// nonce is exactly `new_nonce`.  `consume_nonce` only accepts a value equal
+/// to the stored nonce, so any payload whose `nonce` field satisfies
+/// `nonce < new_nonce` will be rejected with `InvalidNonce`.  Because nonces
+/// are strictly monotone, the half-open range `[0, new_nonce)` is permanently
+/// unspendable for `identity`.  No pre-signed payload can escape invalidation
+/// regardless of when it was produced.
+///
+/// The cap `MAX_NONCE_INVALIDATION_SPAN` limits a single jump to 10 000
+/// nonces.  Larger ranges must be done in multiple calls, each bounded by
+/// the same cap.
 const MAX_NONCE_INVALIDATION_SPAN: u64 = 10_000;
 
 /// Maximum lifetime, in seconds, allowed for a newly created delegation.
@@ -135,6 +151,11 @@ impl CredenceDelegation {
         owner.require_auth();
 
         Self::validate_delegation_expiry(&e, expires_at);
+
+        // Consume nonce so direct-path and delegated-path actions share a
+        // single monotone sequence.  This ensures invalidate_nonce_range
+        // blocks both interaction types uniformly.
+        nonce::consume_nonce(&e, &owner, nonce);
 
         Self::store_delegation(&e, owner, delegate, delegation_type, expires_at)
     }
@@ -535,3 +556,6 @@ mod test_domain_separation;
 
 #[cfg(test)]
 mod test_delegation_ttl;
+
+#[cfg(test)]
+mod test_nonce_replay;

--- a/contracts/credence_delegation/src/nonce.rs
+++ b/contracts/credence_delegation/src/nonce.rs
@@ -120,14 +120,42 @@ pub fn consume_nonce(e: &Env, identity: &Address, expected_nonce: u64) {
     bump_nonce_ttl(e, &key, 0);
 }
 
-/// Advances nonce to `new_nonce`, invalidating the half-open range
+/// Advances nonce to `new_nonce`, permanently invalidating the half-open range
 /// `[current_nonce, new_nonce)`.
 ///
 /// This allows compromised-key recovery by skipping potentially leaked,
 /// pre-signed delegated payloads without submitting each nonce one-by-one.
 ///
+/// ## Replay-Window Proof
+///
+/// **Invariant**: `stored_nonce` is strictly monotone — it only increases.
+///
+/// **Claim**: after `invalidate_nonce_range(identity, new_nonce)` returns
+/// successfully, every payload with `payload.nonce < new_nonce` is permanently
+/// unspendable for `identity`.
+///
+/// **Proof**:
+/// 1. On entry the stored nonce is `current`.  The call panics unless
+///    `new_nonce > current`, so the stored value advances to `new_nonce`.
+/// 2. `consume_nonce` accepts a payload only when
+///    `payload.nonce == stored_nonce`.  After the call the stored nonce is
+///    `new_nonce`.
+/// 3. For any `n < new_nonce`: `n < new_nonce ≤ stored_nonce` (by
+///    monotonicity).  Therefore `n ≠ stored_nonce` for all future states, so
+///    `consume_nonce` will always reject such a payload with `InvalidNonce`.
+/// 4. The argument is independent of when the payload was produced, how many
+///    more invalidations occur, or what the current ledger time is.
+///
+/// **Boundary case**: `new_nonce - 1` is the last invalidated nonce;
+/// `new_nonce` itself is the next spendable nonce.
+///
+/// **Span cap**: `max_span` (= `MAX_NONCE_INVALIDATION_SPAN = 10_000`) limits
+/// each single call to at most 10 000 skipped nonces.  Larger jumps require
+/// multiple calls, each bounded by the same cap, preventing gas exhaustion.
+///
 /// # Panics
-/// Panics if `new_nonce <= current_nonce` or if the span exceeds `max_span`.
+/// - `new_nonce <= current_nonce` — would not advance the nonce.
+/// - `span > max_span` — exceeds the single-call invalidation limit.
 pub fn invalidate_nonce_range(
     e: &Env,
     identity: &Address,

--- a/contracts/credence_delegation/src/test.rs
+++ b/contracts/credence_delegation/src/test.rs
@@ -80,7 +80,7 @@ fn test_delegate_management() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    let d = client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
+    let d = client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64, &0_u64);
 
     assert_eq!(d.owner, owner);
     assert_eq!(d.delegate, delegate);
@@ -92,7 +92,7 @@ fn test_get_delegation() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
 
     let d = client.get_delegation(&owner, &delegate, &DelegationType::Attestation);
     assert_eq!(d.owner, owner);
@@ -123,7 +123,7 @@ fn test_is_valid_delegate() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
 
     assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
 }
@@ -141,8 +141,8 @@ fn test_is_valid_delegate_after_revoke() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Management);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64, &0_u64);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Management, &1_u64);
 
     assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
 }
@@ -152,7 +152,7 @@ fn test_is_valid_delegate_after_expiry() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &100_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &100_u64, &0_u64);
 
     assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
 
@@ -169,11 +169,11 @@ fn test_independent_delegation_types() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
-    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &86400_u64, &1_u64);
 
     // Revoke only attestation
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &2_u64);
 
     assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Attestation));
     assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
@@ -197,7 +197,7 @@ fn test_delegate_with_past_expiry() {
 
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &500_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &500_u64, &0_u64);
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn test_delegate_rejects_expiry_at_now() {
 
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &1000_u64);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &1000_u64, &0_u64);
 }
 
 #[test]
@@ -224,7 +224,7 @@ fn test_delegate_accepts_exact_max_expiry() {
     let delegate = Address::generate(&e);
     let expires_at = e.ledger().timestamp() + MAX_DELEGATION_DURATION;
 
-    let d = client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at);
+    let d = client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at, &0_u64);
 
     assert_eq!(d.expires_at, expires_at);
     assert!(client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
@@ -242,7 +242,7 @@ fn test_delegate_rejects_expiry_over_max() {
     let delegate = Address::generate(&e);
     let expires_at = e.ledger().timestamp() + MAX_DELEGATION_DURATION + 1;
 
-    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at, &0_u64);
 }
 
 #[test]
@@ -252,7 +252,7 @@ fn test_delegate_rejects_u64_max_expiry() {
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
 
-    client.delegate(&owner, &delegate, &DelegationType::Management, &u64::MAX);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &u64::MAX, &0_u64);
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn test_is_valid_delegate_false_at_exact_expiry_boundary() {
     let delegate = Address::generate(&e);
     let expires_at = e.ledger().timestamp() + 10;
 
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at, &0_u64);
     e.ledger().with_mut(|li| {
         li.timestamp = expires_at;
     });
@@ -319,14 +319,14 @@ fn test_revoke_delegation_after_expiry_marks_revoked_and_stays_invalid() {
     let delegate = Address::generate(&e);
     let expires_at = e.ledger().timestamp() + 10;
 
-    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at, &0_u64);
     e.ledger().with_mut(|li| {
         li.timestamp = expires_at;
     });
 
     assert!(!client.is_valid_delegate(&owner, &delegate, &DelegationType::Management));
 
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Management);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Management, &1_u64);
 
     let d = client.get_delegation(&owner, &delegate, &DelegationType::Management);
     assert!(d.revoked);
@@ -349,9 +349,10 @@ fn test_double_revoke() {
     let (e, client) = setup();
     let owner = Address::generate(&e);
     let delegate = Address::generate(&e);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64);
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &1_u64);
+    // Second revoke: nonce=2 passes consume_nonce, then AlreadyRevoked triggers
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &2_u64);
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +373,7 @@ fn test_revoke_attestation_happy_path() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
 
     // Status before revocation
@@ -380,8 +382,8 @@ fn test_revoke_attestation_happy_path() {
         AttestationStatus::Active
     ));
 
-    // Revoke
-    client.revoke_attestation(&attester, &subject);
+    // Revoke (delegate consumed nonce 0, so revoke uses nonce 1)
+    client.revoke_attestation(&attester, &subject, &1_u64);
 
     // Status after revocation
     assert!(matches!(
@@ -403,8 +405,9 @@ fn test_revoke_attestation_history_preserved() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
-    client.revoke_attestation(&attester, &subject);
+    client.revoke_attestation(&attester, &subject, &1_u64);
 
     // Full record must still be reachable via get_delegation
     let d = client.get_delegation(&attester, &subject, &DelegationType::Attestation);
@@ -426,10 +429,11 @@ fn test_revoke_attestation_is_valid_false() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
     assert!(client.is_valid_delegate(&attester, &subject, &DelegationType::Attestation));
 
-    client.revoke_attestation(&attester, &subject);
+    client.revoke_attestation(&attester, &subject, &1_u64);
     assert!(!client.is_valid_delegate(&attester, &subject, &DelegationType::Attestation));
 }
 
@@ -441,7 +445,8 @@ fn test_revoke_attestation_not_found() {
     let attester = Address::generate(&e);
     let subject = Address::generate(&e);
 
-    client.revoke_attestation(&attester, &subject);
+    // nonce=0: consume_nonce(0) succeeds, then DelegationNotFound triggers
+    client.revoke_attestation(&attester, &subject, &0_u64);
 }
 
 /// Double-revoking an attestation must panic with `"Error(Contract, #502)"`.
@@ -457,10 +462,11 @@ fn test_revoke_attestation_double_revoke() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
-    client.revoke_attestation(&attester, &subject);
-    // Second revoke must panic
-    client.revoke_attestation(&attester, &subject);
+    client.revoke_attestation(&attester, &subject, &1_u64);
+    // Second revoke: nonce=2 passes consume_nonce, then AlreadyRevoked triggers
+    client.revoke_attestation(&attester, &subject, &2_u64);
 }
 
 /// `get_attestation_status` returns `Active` for a live attestation.
@@ -475,6 +481,7 @@ fn test_get_attestation_status_active() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
 
     assert!(matches!(
@@ -509,10 +516,11 @@ fn test_revoke_attestation_does_not_affect_management() {
         &subject,
         &DelegationType::Attestation,
         &86400_u64,
+        &0_u64,
     );
-    client.delegate(&attester, &subject, &DelegationType::Management, &86400_u64);
+    client.delegate(&attester, &subject, &DelegationType::Management, &86400_u64, &1_u64);
 
-    client.revoke_attestation(&attester, &subject);
+    client.revoke_attestation(&attester, &subject, &2_u64);
 
     // Attestation is revoked
     assert!(matches!(

--- a/contracts/credence_delegation/src/test_delegation_ttl.rs
+++ b/contracts/credence_delegation/src/test_delegation_ttl.rs
@@ -74,7 +74,7 @@ fn test_delegation_ttl_set_on_write() {
     let now = e.ledger().timestamp();
     let expires_at = now + 30 * 24 * 3600;
 
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at, &0_u64);
 
     let key = DataKey::Delegation(owner.clone(), delegate.clone(), DelegationType::Attestation);
     let ttl = delegation_ttl(&e, &contract_id, &key);
@@ -101,7 +101,7 @@ fn test_delegation_ttl_refreshed_on_get() {
     let now = e.ledger().timestamp();
     let expires_at = now + 60 * 24 * 3600; // 60 days
 
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at, &0_u64);
 
     let key = DataKey::Delegation(owner.clone(), delegate.clone(), DelegationType::Attestation);
     let ttl_after_write = delegation_ttl(&e, &contract_id, &key);
@@ -135,7 +135,7 @@ fn test_delegation_ttl_refreshed_on_is_valid() {
     let now = e.ledger().timestamp();
     let expires_at = now + 30 * 24 * 3600;
 
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at, &0_u64);
 
     let key = DataKey::Delegation(owner.clone(), delegate.clone(), DelegationType::Attestation);
 
@@ -169,6 +169,7 @@ fn test_nonce_ttl_set_on_consume() {
         target: delegate.clone(),
         contract_id: contract_id.clone(),
         nonce: 0,
+        scheme: 0,
     };
     client.execute_delegated_delegate(
         &owner,
@@ -209,6 +210,7 @@ fn test_nonce_ttl_covers_delegation_lifetime() {
         target: delegate.clone(),
         contract_id: contract_id.clone(),
         nonce: 0,
+        scheme: 0,
     };
     client.execute_delegated_delegate(
         &owner,
@@ -250,6 +252,7 @@ fn test_nonce_ttl_refreshed_on_get_nonce() {
         target: delegate.clone(),
         contract_id: contract_id.clone(),
         nonce: 0,
+        scheme: 0,
     };
     client.execute_delegated_delegate(
         &owner,
@@ -290,11 +293,11 @@ fn test_delegation_ttl_bumped_on_revoke() {
     let now = e.ledger().timestamp();
     let expires_at = now + 30 * 24 * 3600;
 
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Attestation, &expires_at, &0_u64);
 
     advance_time(&e, &contract_id, 5 * 24 * 3600);
 
-    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation);
+    client.revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &1_u64);
 
     let key = DataKey::Delegation(owner.clone(), delegate.clone(), DelegationType::Attestation);
     let ttl = delegation_ttl(&e, &contract_id, &key);
@@ -318,7 +321,7 @@ fn test_delegation_ttl_capped_at_max() {
     let now = e.ledger().timestamp();
     let expires_at = now + MAX_DELEGATION_DURATION;
 
-    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at);
+    client.delegate(&owner, &delegate, &DelegationType::Management, &expires_at, &0_u64);
 
     let key = DataKey::Delegation(owner.clone(), delegate.clone(), DelegationType::Management);
     let ttl = delegation_ttl(&e, &contract_id, &key);

--- a/contracts/credence_delegation/src/test_domain_separation.rs
+++ b/contracts/credence_delegation/src/test_domain_separation.rs
@@ -42,6 +42,7 @@ fn make_payload(
         target: target.clone(),
         contract_id: contract_id.clone(),
         nonce,
+        scheme: 0,
     }
 }
 
@@ -89,7 +90,7 @@ fn nonce_increments_after_delegated_delegate() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #504)")]
 fn cross_domain_replay_delegate_payload_in_revoke() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -128,7 +129,7 @@ fn cross_domain_replay_delegate_payload_in_revoke() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #504)")]
 fn cross_domain_replay_revoke_payload_in_delegate() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -160,7 +161,7 @@ fn cross_domain_replay_revoke_payload_in_delegate() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #504)")]
 fn cross_domain_replay_delegate_payload_in_revoke_attestation() {
     let (e, client, contract_id) = setup();
     let attester = Address::generate(&e);
@@ -249,7 +250,7 @@ fn nonce_replay_rejected_cross_domain_stale_nonce() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #507)")]
 fn cross_contract_replay_rejected() {
     let (e, client, _) = setup();
     let owner = Address::generate(&e);
@@ -281,7 +282,7 @@ fn cross_contract_replay_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #505)")]
 fn wrong_owner_in_payload_rejected() {
     let (e, client, contract_id) = setup();
     let real_owner = Address::generate(&e);
@@ -313,7 +314,7 @@ fn wrong_owner_in_payload_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "Error(Contract, #208)")]
+#[should_panic(expected = "Error(Contract, #506)")]
 fn wrong_target_in_payload_rejected() {
     let (e, client, contract_id) = setup();
     let owner = Address::generate(&e);
@@ -473,17 +474,17 @@ fn happy_path_delegated_revoke_attestation() {
     let subject = Address::generate(&e);
     let expiry = e.ledger().timestamp() + 86_400;
 
-    // Create the attestation entry first (direct path, no domain payload needed)
-    client.delegate(&attester, &subject, &DelegationType::Attestation, &expiry);
+    // Create the attestation entry first (direct path consumes nonce 0)
+    client.delegate(&attester, &subject, &DelegationType::Attestation, &expiry, &0_u64);
 
-    // Revoke via relayer
+    // Revoke via relayer (direct path consumed nonce 0, so delegated path uses nonce 1)
     let payload = make_payload(
         &e,
         DomainTag::RevokeAttestation,
         &attester,
         &subject,
         &contract_id,
-        0,
+        1,
     );
     client.execute_delegated_revoke_attest(&attester, &subject, &payload);
 
@@ -491,7 +492,7 @@ fn happy_path_delegated_revoke_attestation() {
         client.get_attestation_status(&attester, &subject),
         AttestationStatus::Revoked
     ));
-    assert_eq!(client.get_nonce(&attester), 1);
+    assert_eq!(client.get_nonce(&attester), 2);
 }
 
 #[test]

--- a/contracts/credence_delegation/src/test_nonce_replay.rs
+++ b/contracts/credence_delegation/src/test_nonce_replay.rs
@@ -1,0 +1,225 @@
+//! Inline replay-window tests for `invalidate_nonce_range`.
+//!
+//! These tests live in `src/` and run under the `no_std` environment, so they
+//! use a deterministic xorshift64 PRNG instead of the `proptest` crate.
+//! The proptest integration tests in `tests/nonce_replay.rs` cover the same
+//! property with 10 000 randomised cases; these tests focus on the boundary
+//! cases and deterministic full-range sweeps.
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Env;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, CredenceDelegationClient<'static>) {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+    (e, client)
+}
+
+fn make_payload(
+    owner: &Address,
+    delegate: &Address,
+    contract_id: &Address,
+    nonce: u64,
+) -> DelegatedActionPayload {
+    DelegatedActionPayload {
+        domain: DomainTag::Delegate,
+        owner: owner.clone(),
+        target: delegate.clone(),
+        contract_id: contract_id.clone(),
+        nonce,
+        scheme: 0,
+    }
+}
+
+/// xorshift64 — fast, deterministic PRNG for no_std property sweeps.
+fn xorshift64(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic boundary cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nonce_replay_span_one_rejects_only_nonce() {
+    let (e, client) = setup();
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &1);
+    assert_eq!(client.get_nonce(&identity), 1);
+
+    // Nonce 0 is invalidated.
+    assert!(
+        client
+            .try_execute_delegated_delegate(
+                &identity,
+                &delegate,
+                &DelegationType::Attestation,
+                &(e.ledger().timestamp() + 86_400),
+                &make_payload(&identity, &delegate, &client.address, 0),
+            )
+            .is_err(),
+        "nonce 0 must be rejected after invalidating [0, 1)"
+    );
+
+    // Nonce 1 is the first valid nonce.
+    client
+        .execute_delegated_delegate(
+            &identity,
+            &delegate,
+            &DelegationType::Attestation,
+            &(e.ledger().timestamp() + 86_400),
+            &make_payload(&identity, &delegate, &client.address, 1),
+        );
+    assert_eq!(client.get_nonce(&identity), 2);
+}
+
+#[test]
+fn nonce_replay_max_span_succeeds_and_rejects_all_prior_nonces() {
+    let (e, client) = setup();
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    // Jump by the maximum allowed span.
+    client.invalidate_nonce_range(&identity, &MAX_NONCE_INVALIDATION_SPAN);
+    assert_eq!(client.get_nonce(&identity), MAX_NONCE_INVALIDATION_SPAN);
+
+    // Every nonce in [0, MAX_NONCE_INVALIDATION_SPAN) must be rejected.
+    for n in [0, 1, 999, 5_000, 9_999] {
+        assert!(
+            client
+                .try_execute_delegated_delegate(
+                    &identity,
+                    &delegate,
+                    &DelegationType::Attestation,
+                    &(e.ledger().timestamp() + 86_400),
+                    &make_payload(&identity, &delegate, &client.address, n),
+                )
+                .is_err(),
+            "nonce {n} must be rejected after full max-span invalidation"
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #208)")]
+fn nonce_replay_over_max_span_panics() {
+    let (e, client) = setup();
+    let identity = Address::generate(&e);
+
+    // MAX_NONCE_INVALIDATION_SPAN + 1 must be rejected.
+    client.invalidate_nonce_range(&identity, &(MAX_NONCE_INVALIDATION_SPAN + 1));
+}
+
+#[test]
+fn nonce_replay_boundary_last_in_range_rejected() {
+    let (e, client) = setup();
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    const NEW_NONCE: u64 = 42;
+
+    client.invalidate_nonce_range(&identity, &NEW_NONCE);
+
+    // new_nonce - 1 = 41 is the last invalidated nonce.
+    assert!(
+        client
+            .try_execute_delegated_delegate(
+                &identity,
+                &delegate,
+                &DelegationType::Attestation,
+                &(e.ledger().timestamp() + 86_400),
+                &make_payload(&identity, &delegate, &client.address, NEW_NONCE - 1),
+            )
+            .is_err(),
+        "nonce {} (last in range) must be rejected",
+        NEW_NONCE - 1
+    );
+}
+
+#[test]
+fn nonce_replay_boundary_first_after_range_accepted() {
+    let (e, client) = setup();
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+    const NEW_NONCE: u64 = 42;
+
+    client.invalidate_nonce_range(&identity, &NEW_NONCE);
+
+    // new_nonce = 42 is the first valid nonce.
+    client.execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_payload(&identity, &delegate, &client.address, NEW_NONCE),
+    );
+    assert_eq!(client.get_nonce(&identity), NEW_NONCE + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic sweep: 10 000 iterations with xorshift64 PRNG
+//
+// Each iteration independently generates (current, span, offset) and verifies
+// that the nonce at offset is rejected after invalidating [current, current+span).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nonce_replay_10k_deterministic_sweep() {
+    let (e, client) = setup();
+    let mut rng: u64 = 0xdeadbeef_12345678;
+
+    for _iter in 0..10_000_u32 {
+        let identity = Address::generate(&e);
+        let delegate = Address::generate(&e);
+
+        // current: 0..100  (small enough for a single MAX_SPAN jump from 0)
+        let current = xorshift64(&mut rng) % 100;
+        // span: 1..=MAX_NONCE_INVALIDATION_SPAN
+        let span = (xorshift64(&mut rng) % MAX_NONCE_INVALIDATION_SPAN) + 1;
+        // offset: 0..span  →  test_nonce in [current, current+span)
+        let offset = xorshift64(&mut rng) % span;
+        let new_nonce = current + span;
+        let test_nonce = current + offset;
+
+        // Advance stored nonce to `current`.
+        if current > 0 {
+            client.invalidate_nonce_range(&identity, &current);
+        }
+
+        // Invalidate [current, new_nonce).
+        client.invalidate_nonce_range(&identity, &new_nonce);
+        assert_eq!(
+            client.get_nonce(&identity),
+            new_nonce,
+            "stored nonce must equal new_nonce after invalidation (iter {_iter})"
+        );
+
+        // Test nonce must be rejected.
+        let result = client.try_execute_delegated_delegate(
+            &identity,
+            &delegate,
+            &DelegationType::Attestation,
+            &(e.ledger().timestamp() + 86_400),
+            &make_payload(&identity, &delegate, &client.address, test_nonce),
+        );
+        assert!(
+            result.is_err(),
+            "iter {_iter}: nonce {test_nonce} must be rejected (range [{current}, {new_nonce}))"
+        );
+    }
+}

--- a/contracts/credence_delegation/tests/nonce_replay.rs
+++ b/contracts/credence_delegation/tests/nonce_replay.rs
@@ -1,0 +1,333 @@
+//! Property tests for `invalidate_nonce_range` — replay-window proof.
+//!
+//! These tests verify the central security invariant:
+//!
+//! > After `invalidate_nonce_range(identity, new_nonce)` succeeds, **every**
+//! > payload whose `nonce` field falls in the half-open range
+//! > `[prev_nonce, new_nonce)` is permanently rejected with `InvalidNonce`,
+//! > regardless of when the payload was produced.
+//!
+//! We exercise this property with **10 000 random (current, span, offset)**
+//! triples, plus deterministic boundary tests for the edge cases explicitly
+//! required by the issue:
+//!
+//! * Invalidation by exactly 1 nonce.
+//! * Invalidation by `MAX_NONCE_INVALIDATION_SPAN` (10 000).
+//! * Attempted invalidation by `MAX_NONCE_INVALIDATION_SPAN + 1` (must fail).
+//! * The upper boundary nonce `new_nonce - 1` is rejected.
+//! * The first post-invalidation nonce `new_nonce` is accepted.
+
+use credence_delegation::{
+    CredenceDelegation, CredenceDelegationClient,
+    DelegatedActionPayload, DomainTag, DelegationType,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Test environment helpers
+// ---------------------------------------------------------------------------
+
+fn make_env() -> Env {
+    let e = Env::default();
+    e.mock_all_auths();
+    e
+}
+
+fn setup_client(e: &Env) -> CredenceDelegationClient<'static> {
+    let contract_id = e.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(e, &contract_id);
+    let admin = Address::generate(e);
+    client.initialize(&admin);
+    client
+}
+
+/// Build a `DelegatedActionPayload` with the given nonce for `execute_delegated_delegate`.
+fn make_delegate_payload(
+    owner: &Address,
+    delegate: &Address,
+    contract_id: &Address,
+    nonce: u64,
+) -> DelegatedActionPayload {
+    DelegatedActionPayload {
+        domain: DomainTag::Delegate,
+        owner: owner.clone(),
+        target: delegate.clone(),
+        contract_id: contract_id.clone(),
+        nonce,
+        scheme: 0,
+    }
+}
+
+/// Advance the identity's stored nonce to `target` using `invalidate_nonce_range`.
+///
+/// Panics if `target == 0` (no advance needed) or if the advance exceeds
+/// `MAX_NONCE_INVALIDATION_SPAN` in one step (splits automatically).
+fn advance_nonce_to(client: &CredenceDelegationClient, identity: &Address, target: u64) {
+    const MAX_SPAN: u64 = 10_000;
+    let mut current = client.get_nonce(identity);
+    while current < target {
+        let step = (target - current).min(MAX_SPAN);
+        client.invalidate_nonce_range(identity, &(current + step));
+        current += step;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Deterministic boundary tests
+// ---------------------------------------------------------------------------
+
+/// Invalidation by exactly 1: nonce 0 becomes unreachable after jump to 1.
+#[test]
+fn boundary_invalidate_by_one() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &1);
+    assert_eq!(client.get_nonce(&identity), 1);
+
+    let result = client.try_execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_delegate_payload(&identity, &delegate, &client.address, 0),
+    );
+    assert!(result.is_err(), "nonce 0 must be rejected after jump to 1");
+}
+
+/// Invalidation by MAX_NONCE_INVALIDATION_SPAN (10 000) succeeds.
+#[test]
+fn boundary_invalidate_max_span_succeeds() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &10_000);
+    assert_eq!(client.get_nonce(&identity), 10_000);
+}
+
+/// Attempting to invalidate by MAX_NONCE_INVALIDATION_SPAN + 1 must fail.
+#[test]
+fn boundary_invalidate_over_max_span_fails() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+
+    let result = client.try_invalidate_nonce_range(&identity, &10_001);
+    assert!(
+        result.is_err(),
+        "span of 10 001 must be rejected (exceeds MAX_NONCE_INVALIDATION_SPAN)"
+    );
+    // Stored nonce must remain unchanged.
+    assert_eq!(client.get_nonce(&identity), 0);
+}
+
+/// The last nonce in the invalidated range (`new_nonce - 1`) must be rejected.
+#[test]
+fn boundary_last_invalidated_nonce_rejected() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    // Invalidate [0, 50) — last invalidated nonce is 49.
+    client.invalidate_nonce_range(&identity, &50);
+
+    let result = client.try_execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_delegate_payload(&identity, &delegate, &client.address, 49),
+    );
+    assert!(result.is_err(), "nonce 49 (last in [0,50)) must be rejected");
+}
+
+/// The first nonce after the invalidated range (`new_nonce`) must be accepted.
+#[test]
+fn boundary_first_valid_nonce_accepted() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &50);
+
+    // nonce 50 is the first valid nonce.
+    client.execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_delegate_payload(&identity, &delegate, &client.address, 50),
+    );
+    assert_eq!(client.get_nonce(&identity), 51);
+}
+
+/// Once a range is invalidated a second invalidation covering the same nonces
+/// from a higher base still rejects the old nonces.
+#[test]
+fn boundary_double_invalidation_still_rejects_old_nonces() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &5);
+    client.invalidate_nonce_range(&identity, &10);
+    assert_eq!(client.get_nonce(&identity), 10);
+
+    for n in 0u64..10 {
+        let result = client.try_execute_delegated_delegate(
+            &identity,
+            &delegate,
+            &DelegationType::Attestation,
+            &(e.ledger().timestamp() + 86_400),
+            &make_delegate_payload(&identity, &delegate, &client.address, n),
+        );
+        assert!(result.is_err(), "nonce {n} must be rejected after two invalidations");
+    }
+}
+
+/// Monotonicity: a new_nonce that is not strictly greater than the stored
+/// nonce must be rejected.
+#[test]
+fn boundary_non_monotone_invalidation_fails() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &5);
+
+    // Trying to set new_nonce = 5 (equal, not greater) must fail.
+    let result = client.try_invalidate_nonce_range(&identity, &5);
+    assert!(result.is_err(), "new_nonce <= stored_nonce must be rejected");
+
+    // Trying to set new_nonce = 3 (less than) must also fail.
+    let result = client.try_invalidate_nonce_range(&identity, &3);
+    assert!(result.is_err(), "new_nonce < stored_nonce must be rejected");
+}
+
+/// After invalidation, a valid subsequent nonce is consumed exactly once.
+#[test]
+fn boundary_post_invalidation_nonce_consumed_once() {
+    let e = make_env();
+    let client = setup_client(&e);
+    let identity = Address::generate(&e);
+    let delegate = Address::generate(&e);
+
+    client.invalidate_nonce_range(&identity, &100);
+
+    // Use nonce 100 successfully.
+    client.execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_delegate_payload(&identity, &delegate, &client.address, 100),
+    );
+
+    // Attempting to replay nonce 100 must now fail.
+    let result = client.try_execute_delegated_delegate(
+        &identity,
+        &delegate,
+        &DelegationType::Attestation,
+        &(e.ledger().timestamp() + 86_400),
+        &make_delegate_payload(&identity, &delegate, &client.address, 100),
+    );
+    assert!(result.is_err(), "replaying nonce 100 after it was consumed must fail");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Property tests — 10 000 random (current, span, offset) triples
+// ---------------------------------------------------------------------------
+
+/// Generate a valid (current_nonce, span, offset_within_span) triple where:
+/// - `current` is the stored nonce before invalidation (0..1_000).
+/// - `span` is the size of the invalidated range (1..=MAX_NONCE_INVALIDATION_SPAN).
+/// - `offset` is the nonce to test — must be in `[current, current + span)`.
+fn nonce_triple() -> impl Strategy<Value = (u64, u64, u64)> {
+    (0u64..1_000u64, 1u64..=10_000u64)
+        .prop_flat_map(|(current, span)| {
+            let offset_strat = 0u64..span;
+            (Just(current), Just(span), offset_strat)
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+    /// Core property: any nonce in `[current, new_nonce)` is rejected after
+    /// `invalidate_nonce_range(identity, new_nonce)`.
+    #[test]
+    fn prop_all_invalidated_nonces_rejected(
+        (current, span, offset) in nonce_triple()
+    ) {
+        let e = make_env();
+        let client = setup_client(&e);
+        let identity = Address::generate(&e);
+        let delegate = Address::generate(&e);
+
+        // Advance stored nonce to `current` (if non-zero).
+        if current > 0 {
+            advance_nonce_to(&client, &identity, current);
+        }
+
+        let new_nonce = current + span;
+        let test_nonce = current + offset; // offset in [0, span) → test_nonce in [current, new_nonce)
+
+        // Invalidate [current, new_nonce).
+        client.invalidate_nonce_range(&identity, &new_nonce);
+        prop_assert_eq!(client.get_nonce(&identity), new_nonce);
+
+        // Any nonce in the invalidated range must be rejected.
+        let result = client.try_execute_delegated_delegate(
+            &identity,
+            &delegate,
+            &DelegationType::Attestation,
+            &(e.ledger().timestamp() + 86_400),
+            &make_delegate_payload(&identity, &delegate, &client.address, test_nonce),
+        );
+        prop_assert!(
+            result.is_err(),
+            "nonce {} must be rejected: stored nonce is {} (invalidated range [{}, {}))",
+            test_nonce, new_nonce, current, new_nonce
+        );
+    }
+
+    /// Corollary: the first nonce after the invalidated range is always accepted.
+    #[test]
+    fn prop_post_invalidation_nonce_accepted(
+        (current, span, _) in nonce_triple()
+    ) {
+        let e = make_env();
+        let client = setup_client(&e);
+        let identity = Address::generate(&e);
+        let delegate = Address::generate(&e);
+
+        if current > 0 {
+            advance_nonce_to(&client, &identity, current);
+        }
+
+        let new_nonce = current + span;
+        client.invalidate_nonce_range(&identity, &new_nonce);
+
+        // new_nonce itself must be accepted (it is the first valid nonce).
+        let result = client.try_execute_delegated_delegate(
+            &identity,
+            &delegate,
+            &DelegationType::Attestation,
+            &(e.ledger().timestamp() + 86_400),
+            &make_delegate_payload(&identity, &delegate, &client.address, new_nonce),
+        );
+        prop_assert!(
+            result.is_ok(),
+            "nonce {} (first post-invalidation) must be accepted",
+            new_nonce
+        );
+    }
+}

--- a/contracts/credence_errors/src/lib.rs
+++ b/contracts/credence_errors/src/lib.rs
@@ -188,22 +188,6 @@ pub enum ContractError {
     /// Wire-stable: do not renumber this error code.
     InvalidNonce = 208,
 
-    /// Payload domain tag does not match the expected delegated action.
-    /// Contracts: bond, delegation
-    DomainMismatch = 218,
-
-    /// Payload owner does not match the expected caller owner.
-    /// Contracts: bond, delegation
-    OwnerMismatch = 219,
-
-    /// Payload target does not match the expected action target.
-    /// Contracts: bond, delegation
-    TargetMismatch = 220,
-
-    /// Payload contract_id does not match the current contract address.
-    /// Contracts: bond, delegation
-    ContractIdMismatch = 221,
-
     /// Signature/operation deadline has passed (now > deadline + grace).
     /// Contracts: bond, delegation
     SignatureExpired = 222,
@@ -382,6 +366,26 @@ pub enum ContractError {
     /// Contracts: delegation
     ContractIdMismatch = 507,
 
+    /// Unknown or unsupported signature scheme tag.
+    /// Contracts: delegation
+    /// Wire-stable: do not renumber this error code.
+    UnknownScheme = 508,
+
+    /// A verifier is already registered for the given scheme tag.
+    /// Contracts: delegation
+    /// Wire-stable: do not renumber this error code.
+    VerifierAlreadyRegistered = 509,
+
+    /// No verifier is registered for the given scheme tag.
+    /// Contracts: delegation
+    /// Wire-stable: do not renumber this error code.
+    VerifierNotRegistered = 510,
+
+    /// Signature verification failed for the given scheme and payload.
+    /// Contracts: delegation
+    /// Wire-stable: do not renumber this error code.
+    VerificationFailed = 511,
+
     // --- Treasury (600-699) ---
     /// Amount argument must be strictly positive (> 0).
     /// Replaces: panic!("amount must be positive")
@@ -479,10 +483,6 @@ impl ErrorExt for ContractError {
             | ContractError::WithdrawalAlreadyRequested
             | ContractError::ReentrancyDetected
             | ContractError::InvalidNonce
-            | ContractError::DomainMismatch
-            | ContractError::OwnerMismatch
-            | ContractError::TargetMismatch
-            | ContractError::ContractIdMismatch
             | ContractError::SignatureExpired
             | ContractError::NegativeStake
             | ContractError::EarlyExitConfigNotSet
@@ -515,7 +515,11 @@ impl ErrorExt for ContractError {
             | ContractError::DomainMismatch
             | ContractError::OwnerMismatch
             | ContractError::TargetMismatch
-            | ContractError::ContractIdMismatch => ErrorCategory::Delegation,
+            | ContractError::ContractIdMismatch
+            | ContractError::UnknownScheme
+            | ContractError::VerifierAlreadyRegistered
+            | ContractError::VerifierNotRegistered
+            | ContractError::VerificationFailed => ErrorCategory::Delegation,
 
             ContractError::AmountMustBePositive
             | ContractError::ThresholdExceedsSigners
@@ -556,10 +560,6 @@ impl ErrorExt for ContractError {
             }
             ContractError::ReentrancyDetected => "Reentrancy detected; call rejected",
             ContractError::InvalidNonce => "Nonce is replayed or out of order",
-            ContractError::DomainMismatch => "Payload domain tag does not match the expected delegated action",
-            ContractError::OwnerMismatch => "Payload owner does not match the expected caller owner",
-            ContractError::TargetMismatch => "Payload target does not match the expected action target",
-            ContractError::ContractIdMismatch => "Payload contract_id does not match the current contract address",
             ContractError::SignatureExpired => "Signature/operation deadline has passed",
             ContractError::NegativeStake => "Attester stake cannot be negative",
             ContractError::EarlyExitConfigNotSet => {


### PR DESCRIPTION
# feature/delegation-nonce-replay-proof

## What was done

This feature introduces a formal, test-backed proof preventing nonce replay attacks in delegated and direct execution paths. It strengthens monotonic nonce guarantees across all execution flows and adds extensive property-based validation.

---

## New files

| File | Purpose |
|------|--------|
| `tests/nonce_replay.rs` | Proptest integration harness with `prop_all_invalidated_nonces_rejected` and `prop_post_invalidation_nonce_accepted` (10,000-case runs) |
| `src/test_nonce_replay.rs` | Deterministic boundary tests + 10,000-iteration xorshift64 PRNG sweep (no_std compatible) |
| `docs/nonce-replay-proof.md` | Formal security proof, threat model, attack vector analysis, and test coverage matrix |

---

## Key changes to existing files

### `lib.rs`
- Introduced `MAX_NONCE_INVALIDATION_SPAN` with formal reasoning
- `delegate()` now routes through `nonce::consume_nonce`
- Ensures both direct and delegated execution share a single monotone nonce stream

### `nonce.rs`
- Expanded documentation for `invalidate_nonce_range`
- Added formal monotonicity proof
- Included boundary-condition and replay attack analysis

### `Cargo.toml`
- Added `rlib` crate type
- Added `proptest` as a dev-dependency for property-based testing

### `credence_errors`
- Removed duplicate bond-range variants (`DomainMismatch=218`, etc.)
- Added missing error codes:
  - `UnknownScheme=508`
  - through `VerificationFailed=511`

---

## Test improvements

- Fixed pre-existing compilation issues:
  - Missing scheme fields in test fixtures
  - Missing nonce parameters in execution paths
  - Updated domain-mismatch expected error mappings (#208 → #504–#507)
- Added:
  - Property-based fuzz coverage (10,000-case runs)
  - PRNG-based stress testing using xorshift64
  - Replay invalidation invariants verified across randomized inputs

---

## Security guarantee

This implementation enforces:

- Strict monotonic nonce consumption across all execution paths
- Guaranteed rejection of replayed or invalidated nonces
- Consistent behavior between direct execution and delegated execution
- Formalized bounds on invalidation windows (`MAX_NONCE_INVALIDATION_SPAN`)


Closes #415 