### PR TITLE
feat(delegation): derive pause proposal_id from action hash for idemp…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ version = "0.1.0"
 dependencies = [
  "credence_errors",
  "insta",
+ "proptest",
  "serde",
  "serde_json",
  "soroban-sdk",

--- a/contracts/credence_bond/benches/cost.rs
+++ b/contracts/credence_bond/benches/cost.rs
@@ -35,11 +35,17 @@ fn main() -> ExitCode {
 
     let regressions = harness::diff(&baseline, &current);
     if regressions.is_empty() {
-        println!("\n✓ no gas regressions (tolerance {:.1}%)", baseline.tolerance_pct);
+        println!(
+            "\n✓ no gas regressions (tolerance {:.1}%)",
+            baseline.tolerance_pct
+        );
         return ExitCode::SUCCESS;
     }
 
-    eprintln!("\n✗ gas regression(s) over {:.1}% tolerance:", baseline.tolerance_pct);
+    eprintln!(
+        "\n✗ gas regression(s) over {:.1}% tolerance:",
+        baseline.tolerance_pct
+    );
     for r in &regressions {
         eprintln!(
             "  {}::{}  {} -> {}  (+{:.1}%)",
@@ -63,7 +69,9 @@ fn print_table(
         "entrypoint", "cpu_insns", "Δ cpu", "rw(r/w)"
     );
     for name in harness::ENTRYPOINTS {
-        let Some(c) = current.get(*name) else { continue };
+        let Some(c) = current.get(*name) else {
+            continue;
+        };
         let delta = baseline
             .costs
             .get(*name)

--- a/contracts/credence_bond/benches/harness.rs
+++ b/contracts/credence_bond/benches/harness.rs
@@ -257,7 +257,9 @@ impl<'a> Reader<'a> {
         while self.b[self.i] != b'"' {
             self.i += 1;
         }
-        let s = std::str::from_utf8(&self.b[start..self.i]).unwrap().to_string();
+        let s = std::str::from_utf8(&self.b[start..self.i])
+            .unwrap()
+            .to_string();
         self.i += 1; // consume closing '"'
         s
     }
@@ -300,8 +302,14 @@ pub struct Baseline {
 
 /// Parse a baseline JSON document produced by [`to_json`].
 pub fn parse_baseline(text: &str) -> Baseline {
-    let root = Reader { b: text.as_bytes(), i: 0 }.value();
-    let tolerance_pct = obj_get(&root, "tolerance_pct").map(as_num).unwrap_or(TOLERANCE_PCT);
+    let root = Reader {
+        b: text.as_bytes(),
+        i: 0,
+    }
+    .value();
+    let tolerance_pct = obj_get(&root, "tolerance_pct")
+        .map(as_num)
+        .unwrap_or(TOLERANCE_PCT);
     let mut costs = BTreeMap::new();
     if let Some(Json::Obj(entries)) = obj_get(&root, "entrypoints") {
         for (name, c) in entries {
@@ -318,7 +326,10 @@ pub fn parse_baseline(text: &str) -> Baseline {
             );
         }
     }
-    Baseline { tolerance_pct, costs }
+    Baseline {
+        tolerance_pct,
+        costs,
+    }
 }
 
 /// A single metric that grew past the tolerance.
@@ -345,7 +356,11 @@ pub fn diff(baseline: &Baseline, current: &BTreeMap<String, EntryCost>) -> Vec<R
             ("cpu_insns", b.cpu_insns, c.cpu_insns),
             ("mem_bytes", b.mem_bytes, c.mem_bytes),
             ("read_entries", b.read_entries as i64, c.read_entries as i64),
-            ("write_entries", b.write_entries as i64, c.write_entries as i64),
+            (
+                "write_entries",
+                b.write_entries as i64,
+                c.write_entries as i64,
+            ),
             ("read_bytes", b.read_bytes as i64, c.read_bytes as i64),
             ("write_bytes", b.write_bytes as i64, c.write_bytes as i64),
         ];

--- a/contracts/credence_bond/src/events.rs
+++ b/contracts/credence_bond/src/events.rs
@@ -452,4 +452,3 @@ pub fn emit_bond_drift_detected(e: &Env, details: &crate::invariants::BondDriftD
     );
     e.events().publish(topics, data);
 }
-

--- a/contracts/credence_bond/src/fork_base.rs
+++ b/contracts/credence_bond/src/fork_base.rs
@@ -1,5 +1,5 @@
-use crate::{IdentityBond, DataKey, BondTier};
 use crate::{early_exit_penalty, rolling_bond, tiered_bond};
+use crate::{BondTier, DataKey, IdentityBond};
 
 use credence_errors::ContractError;
 use soroban_sdk::{
@@ -132,7 +132,9 @@ impl CredenceBond {
 
         let counter_key = DataKey::AttestationCounter;
         let id: u64 = e.storage().instance().get(&counter_key).unwrap_or(0);
-        let next_id = id.checked_add(1).unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
+        let next_id = id
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
         e.storage().instance().set(&counter_key, &next_id);
 
         let attestation = Attestation {

--- a/contracts/credence_bond/src/fork_divergent.rs
+++ b/contracts/credence_bond/src/fork_divergent.rs
@@ -1,5 +1,5 @@
-use crate::{IdentityBond, DataKey, BondTier};
 use crate::{early_exit_penalty, rolling_bond, tiered_bond};
+use crate::{BondTier, DataKey, IdentityBond};
 
 use credence_errors::ContractError;
 use soroban_sdk::{

--- a/contracts/credence_bond/src/fork_ours.rs
+++ b/contracts/credence_bond/src/fork_ours.rs
@@ -1,11 +1,10 @@
-use crate::{IdentityBond, DataKey, BondTier, Attestation};
 use crate::types::AttestationDedupKey;
 use crate::{early_exit_penalty, nonce, rolling_bond, slashing, tiered_bond, weighted_attestation};
+use crate::{Attestation, BondTier, DataKey, IdentityBond};
 
 use credence_errors::ContractError;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, panic_with_error, Address, Env, String, Symbol,
-    Val, Vec,
+    contract, contractimpl, contracttype, panic_with_error, Address, Env, String, Symbol, Val, Vec,
 };
 
 // Re-export attestation type (definitions and validation in types::attestation).
@@ -539,7 +538,12 @@ impl CredenceBond {
         bump_instance_ttl(&e);
         e.events().publish(
             (Symbol::new(&e, "bond_topped_up"),),
-            (bond.identity.clone(), old_amount, bond.bonded_amount, timestamp),
+            (
+                bond.identity.clone(),
+                old_amount,
+                bond.bonded_amount,
+                timestamp,
+            ),
         );
         bond
     }
@@ -569,7 +573,12 @@ impl CredenceBond {
         bump_instance_ttl(&e);
         e.events().publish(
             (Symbol::new(&e, "bond_duration_extended"),),
-            (bond.identity.clone(), old_duration, bond.bond_duration, timestamp),
+            (
+                bond.identity.clone(),
+                old_duration,
+                bond.bond_duration,
+                timestamp,
+            ),
         );
         bond
     }

--- a/contracts/credence_bond/src/fork_theirs.rs
+++ b/contracts/credence_bond/src/fork_theirs.rs
@@ -1,5 +1,5 @@
-use crate::{IdentityBond, DataKey, BondTier};
 use crate::{early_exit_penalty, rolling_bond, tiered_bond};
+use crate::{BondTier, DataKey, IdentityBond};
 
 use credence_errors::ContractError;
 use soroban_sdk::{

--- a/contracts/credence_bond/src/invariants.rs
+++ b/contracts/credence_bond/src/invariants.rs
@@ -49,11 +49,7 @@ pub struct BondDriftDetails {
 /// [`ContractError::InvariantViolation`] so indexers can alert before the transaction aborts.
 pub fn assert_self_consistent(e: &Env) {
     let bond_key = DataKey::Bond;
-    let Some(bond) = e
-        .storage()
-        .instance()
-        .get::<_, IdentityBond>(&bond_key)
-    else {
+    let Some(bond) = e.storage().instance().get::<_, IdentityBond>(&bond_key) else {
         return;
     };
 
@@ -97,9 +93,7 @@ pub fn assert_self_consistent_for_subject(e: &Env, subject: &Address) {
 }
 
 fn check_bond_slashed_within_bonded(e: &Env, bond: &IdentityBond) {
-    if bond.slashed_amount > bond.bonded_amount
-        || bond.bonded_amount < 0
-        || bond.slashed_amount < 0
+    if bond.slashed_amount > bond.bonded_amount || bond.bonded_amount < 0 || bond.slashed_amount < 0
     {
         fail_drift(
             e,

--- a/contracts/credence_bond/src/lib.rs
+++ b/contracts/credence_bond/src/lib.rs
@@ -1669,10 +1669,10 @@ mod tests {
 mod test_bond_drift;
 
 #[cfg(test)]
-pub mod fork_ours;
-#[cfg(test)]
 pub mod fork_base;
 #[cfg(test)]
-pub mod fork_theirs;
-#[cfg(test)]
 pub mod fork_divergent;
+#[cfg(test)]
+pub mod fork_ours;
+#[cfg(test)]
+pub mod fork_theirs;

--- a/contracts/credence_bond/src/migration.rs
+++ b/contracts/credence_bond/src/migration.rs
@@ -1,6 +1,6 @@
 //! Storage migration utilities for IdentityBond
+use crate::{DataKey, IdentityBond};
 use soroban_sdk::Env;
-use crate::{IdentityBond, DataKey};
 
 /// Perform lazy migration of IdentityBond storage from v1 to v2 format.
 ///

--- a/contracts/credence_bond/src/nonce.rs
+++ b/contracts/credence_bond/src/nonce.rs
@@ -1,5 +1,5 @@
 //! Nonce tracking for replay prevention in the credence bond contract.
-//! 
+//!
 //! Safety buffer added on top of the nonce TTL.
 const MIN_NONCE_TTL: u32 = 518_400;
 
@@ -127,5 +127,7 @@ pub fn validate_and_consume_with_grace(
 }
 
 fn bump_nonce_ttl(e: &Env, key: &DataKey, _ttl: u32) {
-    e.storage().instance().extend_ttl(MIN_NONCE_TTL, MIN_NONCE_TTL * 2);
+    e.storage()
+        .instance()
+        .extend_ttl(MIN_NONCE_TTL, MIN_NONCE_TTL * 2);
 }

--- a/contracts/credence_bond/src/slashing.rs
+++ b/contracts/credence_bond/src/slashing.rs
@@ -384,4 +384,3 @@ pub fn slash_bond_with_identity(
 ) -> crate::IdentityBond {
     slash_bond(e, admin, slash_amount)
 }
-

--- a/contracts/credence_bond/src/test_bond_drift.rs
+++ b/contracts/credence_bond/src/test_bond_drift.rs
@@ -70,8 +70,8 @@ fn bond_drift_slashed_over_bonded_emits_structured_event() {
     }));
     assert!(panic_result.is_err(), "expected InvariantViolation panic");
 
-    let (kind, bonded, slashed, _count, _list_len) = last_bond_drift_event(&e)
-        .expect("bond_drift_detected event must be emitted before panic");
+    let (kind, bonded, slashed, _count, _list_len) =
+        last_bond_drift_event(&e).expect("bond_drift_detected event must be emitted before panic");
     assert_eq!(kind, BondDriftKind::SlashedExceedsBonded);
     assert_eq!(bonded, 1_000);
     assert_eq!(slashed, 1_100);

--- a/contracts/credence_bond/src/test_chaos.rs
+++ b/contracts/credence_bond/src/test_chaos.rs
@@ -122,7 +122,10 @@ mod tests {
         let bond = client.get_identity_state();
         assert_eq!(bond.slashed_amount, 0, "slashed_amount must revert to 0");
         assert_eq!(bond.bonded_amount, 1000, "bonded_amount must be unchanged");
-        assert!(!client.is_locked(), "lock must be released after atomic revert");
+        assert!(
+            !client.is_locked(),
+            "lock must be released after atomic revert"
+        );
     }
 
     // ── Injection #2 ─────────────────────────────────────────────────────────
@@ -142,11 +145,17 @@ mod tests {
         assert!(client.get_identity_state().active);
 
         let result = client.try_withdraw_bond(&identity);
-        assert!(result.is_err(), "withdraw_bond must fail when callback panics");
+        assert!(
+            result.is_err(),
+            "withdraw_bond must fail when callback panics"
+        );
 
         // INVARIANT
         let bond = client.get_identity_state();
-        assert!(bond.active, "bond must remain active after callback-induced rollback");
+        assert!(
+            bond.active,
+            "bond must remain active after callback-induced rollback"
+        );
         assert_eq!(bond.bonded_amount, 1000, "bonded_amount must not be zeroed");
         assert!(!client.is_locked(), "lock must be released");
     }
@@ -173,7 +182,10 @@ mod tests {
 
         // collect_fees: zeros fee storage, calls on_collect → panic → rollback.
         let result = client.try_collect_fees(&admin);
-        assert!(result.is_err(), "collect_fees must fail when callback panics");
+        assert!(
+            result.is_err(),
+            "collect_fees must fail when callback panics"
+        );
 
         // INVARIANT: fees must be intact. Verify via a clean second call.
         let noop = e.register(NoOpCallback, ());

--- a/contracts/credence_bond/src/test_invariants.rs
+++ b/contracts/credence_bond/src/test_invariants.rs
@@ -59,7 +59,9 @@ const SKIP_SLASH_INVARIANT: bool = cfg!(skip_slash_invariant);
 /// `initialize`). Callers that require a bond should use [`load_bond`].
 pub fn try_load_bond(env: &Env, contract: &Address) -> Option<IdentityBond> {
     env.as_contract(contract, || {
-        env.storage().instance().get::<_, IdentityBond>(&DataKey::Bond)
+        env.storage()
+            .instance()
+            .get::<_, IdentityBond>(&DataKey::Bond)
     })
 }
 
@@ -83,7 +85,11 @@ pub fn load_bond(env: &Env, contract: &Address) -> IdentityBond {
 /// when summed as a signed integer.
 ///
 /// Owner module: `SubjectAttestationCount` / `weighted_attestation`.
-pub fn assert_attestation_weight_sum_non_negative(env: &Env, contract: &Address, subject: &Address) {
+pub fn assert_attestation_weight_sum_non_negative(
+    env: &Env,
+    contract: &Address,
+    subject: &Address,
+) {
     let sum = attestation_weight_sum(env, contract, subject);
     assert!(
         sum >= 0,

--- a/contracts/credence_bond/src/types/mod.rs
+++ b/contracts/credence_bond/src/types/mod.rs
@@ -1,0 +1,6 @@
+/// Bond configuration and state types.
+///
+/// Type definitions are co-located with their respective domain modules
+/// (rolling_bond, tiered_bond, etc.). This module is reserved for shared
+/// types that span multiple bond subsystems.
+pub struct Types;

--- a/contracts/credence_delegation/Cargo.toml
+++ b/contracts/credence_delegation/Cargo.toml
@@ -15,3 +15,4 @@ credence_errors = { path = "../credence_errors" }
 insta = { version = "1.34", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+proptest = "1.0"

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -588,6 +588,21 @@ impl CredenceDelegation {
         pausable::get_pause_proposal_state(&e, proposal_id, &signers)
     }
 
+    /// Compatibility shim: resolve a proposal that was recorded under a
+    /// counter-based ID (issued before the hash-derivation migration).
+    ///
+    /// Returns the raw action value (`1` = Pause, `2` = Unpause) if the
+    /// proposal is still in storage, or `ContractError::ProposalNotFound`
+    /// if no proposal exists under that ID. Does **not** panic.
+    ///
+    /// New code should use [`get_pause_proposal_state`] with a hash-derived ID
+    /// instead. This entry point exists solely for backward compatibility with
+    /// clients that persisted counter-based IDs before the migration.
+    pub fn get_proposal_by_legacy_id(e: Env, legacy_id: u64) -> u32 {
+        pausable::get_proposal_by_legacy_id(&e, legacy_id)
+            .unwrap_or_else(|err| panic_with_error!(&e, err))
+    }
+
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
@@ -704,11 +719,14 @@ impl CredenceDelegation {
 // #[cfg(test)]
 // mod test_verifier;
 
-// #[cfg(test)]
-// mod test_pausable;
+#[cfg(test)]
+mod test_pausable;
 
 // #[cfg(test)]
 // mod test_pause_signer_invariant;
+
+#[cfg(test)]
+mod test_proposal_id_derivation;
 
 // #[cfg(test)]
 // mod test_domain_separation;

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -533,9 +533,7 @@ impl CredenceDelegation {
     /// Clients can use this to check scheme support before submitting
     /// delegated payloads.
     pub fn get_verifier(e: Env, scheme: u32) -> Option<Address> {
-        e.storage()
-            .instance()
-            .get(&DataKey::Verifier(scheme))
+        e.storage().instance().get(&DataKey::Verifier(scheme))
     }
 
     // -----------------------------------------------------------------------
@@ -718,7 +716,6 @@ impl CredenceDelegation {
 
 // #[cfg(test)]
 // mod test_verifier;
-
 #[cfg(test)]
 mod test_pausable;
 

--- a/contracts/credence_delegation/src/pausable.rs
+++ b/contracts/credence_delegation/src/pausable.rs
@@ -1,5 +1,5 @@
 use credence_errors::ContractError;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env, Symbol, Vec};
+use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, Env, Symbol, Vec};
 
 use crate::DataKey;
 
@@ -15,8 +15,8 @@ pub enum PauseAction {
 ///
 /// This struct is the typed result of [`get_pause_proposal_state`], which
 /// **aggregates four distinct storage entries** into one read:
-/// * [`DataKey::PauseProposalCounter`] — to tell an allocated id from one that
-///   was never issued (and so derive `executed`).
+/// * [`DataKey::PauseProposalCounter`] — retained for backward compatibility
+///   with clients that stored counter-based IDs before the hash migration.
 /// * [`DataKey::PauseProposal`] — the proposed action payload.
 /// * [`DataKey::PauseApproval`] — the per-signer approval flags.
 /// * [`DataKey::PauseApprovalCount`] — the running approval tally.
@@ -33,9 +33,76 @@ pub struct PauseProposalView {
     /// The subset of the caller-supplied `signers` that have approved. See
     /// [`get_pause_proposal_state`] for why the candidate set must be supplied.
     pub approved_by: Vec<Address>,
-    /// `true` when the id was allocated by the counter but its payload is gone —
-    /// i.e. the proposal has been executed (or otherwise cleared).
+    /// `true` when the proposal was executed (payload cleared).
+    /// For hash-derived IDs this is detected via surviving approval keys in the
+    /// supplied `signers` set; for legacy counter-based IDs it is detected via
+    /// the counter. See [`get_pause_proposal_state`] for details.
     pub executed: bool,
+}
+
+/// Number of ledger sequences that form one epoch bucket for proposal-ID
+/// derivation.
+///
+/// **Tradeoff:** a wider bucket (larger N) gives operators a longer window in
+/// which concurrent submissions of the same action converge to one ID, but also
+/// means a new `(action, target_ledger)` pair cannot be re-proposed until the
+/// next epoch begins — even after the previous proposal is executed.  A narrow
+/// bucket (smaller N) reduces the convergence window and increases the chance
+/// that two operators straddle an epoch boundary.
+///
+/// 100 ledgers ≈ 8 minutes on Stellar (≈ 5-second close times), which is
+/// comfortably wider than any realistic multisig signing round-trip.
+pub const PROPOSAL_EPOCH_SIZE: u32 = 100;
+
+/// Derive a stable, deterministic proposal ID from an action and the current
+/// epoch.
+///
+/// # Derivation rule
+///
+/// ```text
+/// epoch   = ledger_sequence / PROPOSAL_EPOCH_SIZE
+/// preimage = action_u32_big_endian ++ epoch_u32_big_endian   (8 bytes)
+/// hash    = SHA-256(preimage)                                  (32 bytes)
+/// id      = first 8 bytes of hash interpreted as big-endian u64
+/// ```
+///
+/// # Idempotency guarantee
+///
+/// Any number of operators calling `propose_action` with the **same** `action`
+/// during the **same** epoch produce the **same** `proposal_id`.  Votes
+/// therefore accumulate on a single shared proposal regardless of submission
+/// order or count.
+///
+/// # Limits
+///
+/// The guarantee does *not* extend across epoch boundaries: the same action
+/// submitted in epoch *k* and epoch *k+1* yields two different IDs and two
+/// independent proposals.  This is intentional — it allows re-proposing the
+/// same action after a previous epoch's proposal was abandoned without reaching
+/// quorum.
+///
+/// The helper is **pure**: identical inputs always produce identical output;
+/// it reads the ledger sequence from `env` but writes nothing to storage.
+fn derive_proposal_id(e: &Env, action: PauseAction) -> u64 {
+    let epoch = e.ledger().sequence() / PROPOSAL_EPOCH_SIZE;
+    let action_u32 = action as u32;
+
+    // Build an 8-byte preimage: 4 bytes action || 4 bytes epoch (big-endian).
+    let preimage = Bytes::from_array(e, &[
+        ((action_u32 >> 24) & 0xff) as u8,
+        ((action_u32 >> 16) & 0xff) as u8,
+        ((action_u32 >> 8) & 0xff) as u8,
+        (action_u32 & 0xff) as u8,
+        ((epoch >> 24) & 0xff) as u8,
+        ((epoch >> 16) & 0xff) as u8,
+        ((epoch >> 8) & 0xff) as u8,
+        (epoch & 0xff) as u8,
+    ]);
+
+    let hash = e.crypto().sha256(&preimage);
+
+    let b = hash.to_array();
+    u64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
 }
 
 fn require_admin_auth(e: &Env, admin: &Address) {
@@ -171,25 +238,6 @@ fn require_pause_signer(e: &Env, signer: &Address) {
     }
 }
 
-/// Allocate a unique pause proposal id and advance the counter.
-///
-/// `PauseProposalCounter` stores the next unused proposal id.
-/// The allocated id is returned, and the counter is incremented to prevent reuse.
-fn next_proposal_id(e: &Env) -> u64 {
-    let id: u64 = e
-        .storage()
-        .instance()
-        .get(&DataKey::PauseProposalCounter)
-        .unwrap_or(0);
-    let next = id
-        .checked_add(1)
-        .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
-    e.storage()
-        .instance()
-        .set(&DataKey::PauseProposalCounter, &next);
-    id
-}
-
 fn record_approval(e: &Env, proposal_id: u64, signer: &Address) {
     let approval_key = DataKey::PauseApproval(proposal_id, signer.clone());
     if e.storage().instance().has(&approval_key) {
@@ -252,21 +300,34 @@ pub fn unpause(e: &Env, caller: &Address) -> Option<u64> {
     }
 }
 
+/// Submit a pause or unpause proposal.
+///
+/// The proposal ID is derived deterministically from `(action, epoch)` rather
+/// than from a counter. If a proposal with the same ID already exists in
+/// storage the submission is **idempotent**: the existing proposal is not
+/// overwritten, no error is returned, and the submitter's approval is recorded
+/// on the shared proposal. Votes therefore accumulate correctly regardless of
+/// how many operators submit the same action in the same epoch.
 fn propose_action(e: &Env, caller: &Address, action: PauseAction) -> Option<u64> {
     require_pause_signer(e, caller);
 
-    let id = next_proposal_id(e);
-    e.storage()
-        .instance()
-        .set(&DataKey::PauseProposal(id), &(action as u32));
-    e.storage()
-        .instance()
-        .set(&DataKey::PauseApprovalCount(id), &0_u32);
+    let id = derive_proposal_id(e, action);
+    let proposal_key = DataKey::PauseProposal(id);
+
+    // Idempotent: only write the proposal record if it does not already exist.
+    if !e.storage().instance().has(&proposal_key) {
+        e.storage()
+            .instance()
+            .set(&proposal_key, &(action as u32));
+        e.storage()
+            .instance()
+            .set(&DataKey::PauseApprovalCount(id), &0_u32);
+
+        e.events()
+            .publish((Symbol::new(e, "pause_proposed"), id), action as u32);
+    }
 
     record_approval(e, id, caller);
-
-    e.events()
-        .publish((Symbol::new(e, "pause_proposed"), id), action as u32);
 
     Some(id)
 }
@@ -335,6 +396,27 @@ fn do_unpause(e: &Env, proposal_id: Option<u64>) {
         .publish((Symbol::new(e, "unpaused"),), proposal_id);
 }
 
+/// Fetch a proposal that was recorded under a legacy counter-based ID.
+///
+/// **Compatibility shim**: before the hash-derivation migration, proposal IDs
+/// were issued by a monotone counter (`PauseProposalCounter`). Clients that
+/// persisted those numeric IDs can use this function to resolve them.  If the
+/// proposal is not found under the given ID the function returns
+/// `Err(ContractError::ProposalNotFound)` rather than panicking, so callers
+/// can distinguish a stale counter-ID from a network error.
+///
+/// This function is intentionally **not** the primary resolution path for
+/// new proposals; use [`get_pause_proposal_state`] for those.
+pub fn get_proposal_by_legacy_id(
+    e: &Env,
+    legacy_id: u64,
+) -> Result<u32, ContractError> {
+    e.storage()
+        .instance()
+        .get(&DataKey::PauseProposal(legacy_id))
+        .ok_or(ContractError::ProposalNotFound)
+}
+
 /// Aggregate the full state of a pause proposal into a single typed view.
 ///
 /// This is **read-only**: it performs no `require_auth` and never mutates
@@ -351,10 +433,13 @@ fn do_unpause(e: &Env, proposal_id: Option<u64>) {
 ///
 /// Field derivation:
 /// * `action` is `0` when no live payload exists for `proposal_id`.
-/// * `executed` is `true` when the id is below the counter (it was allocated)
-///   yet has no live payload (it was executed/cleared). A never-allocated id
-///   (`proposal_id >= PauseProposalCounter`) reports `action = 0, executed =
-///   false`.
+/// * `executed` is `true` when the proposal's payload was cleared by execution.
+///   Two detection paths are used: (a) legacy counter path — `proposal_id <
+///   counter && !has_payload`; (b) hash-derived path — `!has_payload &&
+///   approved_by.len() > 0` (per-signer approval keys survive execution while
+///   the payload and approval count are removed). Supplying a non-empty
+///   `signers` set that includes at least one approver ensures the hash-derived
+///   path fires correctly.
 pub fn get_pause_proposal_state(
     e: &Env,
     proposal_id: u64,
@@ -362,8 +447,7 @@ pub fn get_pause_proposal_state(
 ) -> PauseProposalView {
     let store = e.storage().instance();
 
-    // Read 1: the counter, to distinguish allocated-then-cleared ids from
-    // ids that were never issued.
+    // Read 1: the legacy counter, for backward-compatible `executed` detection.
     let counter: u64 = store.get(&DataKey::PauseProposalCounter).unwrap_or(0);
 
     // Read 2: the action payload. Absent (0) once executed or if never created.
@@ -386,7 +470,26 @@ pub fn get_pause_proposal_state(
         }
     }
 
-    let executed = proposal_id < counter && !has_payload;
+    // `executed` is true when a proposal was run to completion and its payload
+    // was cleared by `execute_pause_proposal`.
+    //
+    // For legacy counter-based IDs: the counter was incremented at proposal
+    // time, so `proposal_id < counter && !has_payload` is sufficient.
+    //
+    // For hash-derived IDs: the counter is never incremented, so the counter
+    // check cannot detect executed state. Instead we use the surviving
+    // per-signer approval keys (which `execute_pause_proposal` does not remove)
+    // as the signal: if the payload is absent yet at least one signer in the
+    // supplied candidate set has an approval flag, the proposal was executed.
+    let executed = if !has_payload {
+        // Legacy path: counter covers the ID.
+        let legacy_executed = proposal_id < counter;
+        // Hash-derived path: surviving approval key(s) in the supplied set.
+        let hash_executed = !approved_by.is_empty();
+        legacy_executed || hash_executed
+    } else {
+        false
+    };
 
     PauseProposalView {
         proposal_id,

--- a/contracts/credence_delegation/src/pausable.rs
+++ b/contracts/credence_delegation/src/pausable.rs
@@ -88,16 +88,19 @@ fn derive_proposal_id(e: &Env, action: PauseAction) -> u64 {
     let action_u32 = action as u32;
 
     // Build an 8-byte preimage: 4 bytes action || 4 bytes epoch (big-endian).
-    let preimage = Bytes::from_array(e, &[
-        ((action_u32 >> 24) & 0xff) as u8,
-        ((action_u32 >> 16) & 0xff) as u8,
-        ((action_u32 >> 8) & 0xff) as u8,
-        (action_u32 & 0xff) as u8,
-        ((epoch >> 24) & 0xff) as u8,
-        ((epoch >> 16) & 0xff) as u8,
-        ((epoch >> 8) & 0xff) as u8,
-        (epoch & 0xff) as u8,
-    ]);
+    let preimage = Bytes::from_array(
+        e,
+        &[
+            ((action_u32 >> 24) & 0xff) as u8,
+            ((action_u32 >> 16) & 0xff) as u8,
+            ((action_u32 >> 8) & 0xff) as u8,
+            (action_u32 & 0xff) as u8,
+            ((epoch >> 24) & 0xff) as u8,
+            ((epoch >> 16) & 0xff) as u8,
+            ((epoch >> 8) & 0xff) as u8,
+            (epoch & 0xff) as u8,
+        ],
+    );
 
     let hash = e.crypto().sha256(&preimage);
 
@@ -316,9 +319,7 @@ fn propose_action(e: &Env, caller: &Address, action: PauseAction) -> Option<u64>
 
     // Idempotent: only write the proposal record if it does not already exist.
     if !e.storage().instance().has(&proposal_key) {
-        e.storage()
-            .instance()
-            .set(&proposal_key, &(action as u32));
+        e.storage().instance().set(&proposal_key, &(action as u32));
         e.storage()
             .instance()
             .set(&DataKey::PauseApprovalCount(id), &0_u32);
@@ -407,10 +408,7 @@ fn do_unpause(e: &Env, proposal_id: Option<u64>) {
 ///
 /// This function is intentionally **not** the primary resolution path for
 /// new proposals; use [`get_pause_proposal_state`] for those.
-pub fn get_proposal_by_legacy_id(
-    e: &Env,
-    legacy_id: u64,
-) -> Result<u32, ContractError> {
+pub fn get_proposal_by_legacy_id(e: &Env, legacy_id: u64) -> Result<u32, ContractError> {
     e.storage()
         .instance()
         .get(&DataKey::PauseProposal(legacy_id))

--- a/contracts/credence_delegation/src/test_pausable.rs
+++ b/contracts/credence_delegation/src/test_pausable.rs
@@ -91,9 +91,8 @@ fn test_pause_proposal_id_uniqueness_and_scoped_approval_lifecycle() {
     let proposal_a = client.pause(&s1).unwrap();
     let proposal_b = client.unpause(&s2).unwrap();
 
+    // IDs are derived from (action, epoch), so Pause and Unpause must differ.
     assert_ne!(proposal_a, proposal_b);
-    assert_eq!(proposal_a, 0);
-    assert_eq!(proposal_b, 1);
 
     client.approve_pause_proposal(&s2, &proposal_a);
     assert!(client.try_execute_pause_proposal(&proposal_b).is_err());

--- a/contracts/credence_delegation/src/test_pausable.rs
+++ b/contracts/credence_delegation/src/test_pausable.rs
@@ -39,16 +39,30 @@ fn test_pause_blocks_state_changes_but_allows_reads() {
 
     // State changes should fail
     assert!(client
-        .try_delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64)
+        .try_delegate(
+            &owner,
+            &delegate,
+            &DelegationType::Attestation,
+            &86400_u64,
+            &0_u64
+        )
         .is_err());
 
-    assert!(client.try_revoke_attestation(&owner, &delegate, &0_u64).is_err());
+    assert!(client
+        .try_revoke_attestation(&owner, &delegate, &0_u64)
+        .is_err());
 
     client.unpause(&admin);
     assert!(!client.is_paused());
 
     // State change works again
-    let _ = client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    let _ = client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
 }
 
 #[test]
@@ -157,7 +171,13 @@ fn test_delegate_paused() {
     let delegate = Address::generate(&env);
     client.pause(&admin);
     assert!(client
-        .try_delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64)
+        .try_delegate(
+            &owner,
+            &delegate,
+            &DelegationType::Attestation,
+            &86400_u64,
+            &0_u64
+        )
         .is_err());
 }
 
@@ -166,7 +186,13 @@ fn test_revoke_delegation_paused() {
     let (env, admin, client) = setup();
     let owner = Address::generate(&env);
     let delegate = Address::generate(&env);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
     client.pause(&admin);
     assert!(client
         .try_revoke_delegation(&owner, &delegate, &DelegationType::Attestation, &0_u64)
@@ -178,9 +204,17 @@ fn test_revoke_attestation_paused() {
     let (env, admin, client) = setup();
     let owner = Address::generate(&env);
     let delegate = Address::generate(&env);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
     client.pause(&admin);
-    assert!(client.try_revoke_attestation(&owner, &delegate, &0_u64).is_err());
+    assert!(client
+        .try_revoke_attestation(&owner, &delegate, &0_u64)
+        .is_err());
 }
 
 #[test]
@@ -195,6 +229,7 @@ fn test_execute_delegated_delegate_paused() {
         domain: DomainTag::Delegate,
         owner: owner.clone(),
         target: delegate.clone(),
+        scheme: 0,
     };
     assert!(client
         .try_execute_delegated_delegate(
@@ -212,7 +247,13 @@ fn test_execute_delegated_revoke_paused() {
     let (env, admin, client) = setup();
     let owner = Address::generate(&env);
     let delegate = Address::generate(&env);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
     client.pause(&admin);
     let payload = DelegatedActionPayload {
         nonce: 0,
@@ -220,6 +261,7 @@ fn test_execute_delegated_revoke_paused() {
         domain: DomainTag::RevokeDelegation,
         owner: owner.clone(),
         target: delegate.clone(),
+        scheme: 0,
     };
     assert!(client
         .try_execute_delegated_revoke(&owner, &delegate, &DelegationType::Attestation, &payload)
@@ -231,7 +273,13 @@ fn test_execute_delegated_revoke_attest_paused() {
     let (env, admin, client) = setup();
     let owner = Address::generate(&env);
     let delegate = Address::generate(&env);
-    client.delegate(&owner, &delegate, &DelegationType::Attestation, &86400_u64, &0_u64);
+    client.delegate(
+        &owner,
+        &delegate,
+        &DelegationType::Attestation,
+        &86400_u64,
+        &0_u64,
+    );
     client.pause(&admin);
     let payload = DelegatedActionPayload {
         nonce: 0,
@@ -239,6 +287,7 @@ fn test_execute_delegated_revoke_attest_paused() {
         domain: DomainTag::RevokeAttestation,
         owner: owner.clone(),
         target: delegate.clone(),
+        scheme: 0,
     };
     assert!(client
         .try_execute_delegated_revoke_attest(&owner, &delegate, &payload)

--- a/contracts/credence_delegation/src/test_pause_proposal_view.rs
+++ b/contracts/credence_delegation/src/test_pause_proposal_view.rs
@@ -38,7 +38,12 @@ fn setup() -> Setup {
     client.set_pause_signer(&admin, &s2, &true);
     client.set_pause_threshold(&admin, &2);
 
-    Setup { e, client, contract_id, signers: [s1, s2] }
+    Setup {
+        e,
+        client,
+        contract_id,
+        signers: [s1, s2],
+    }
 }
 
 /// Direct per-key reads, executed inside the contract's storage context, so we

--- a/contracts/credence_delegation/src/test_proposal_id_derivation.rs
+++ b/contracts/credence_delegation/src/test_proposal_id_derivation.rs
@@ -1,0 +1,210 @@
+//! Tests for deterministic pause proposal-ID derivation.
+//!
+//! Covers:
+//! 1. Duplicate submission idempotency within the same epoch.
+//! 2. Different epoch yields a different proposal ID.
+//! 3. Simultaneous submission within the same epoch produces exactly one record.
+//! 4. Epoch boundary: ledger N*EPOCH_SIZE-1 vs N*EPOCH_SIZE → different IDs.
+//! 5. Vote accumulation after duplicate submission.
+//! 6. Legacy fetch by counter-based ID returns a typed error, not a panic.
+
+#![cfg(test)]
+
+use super::*;
+use crate::pausable::PROPOSAL_EPOCH_SIZE;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, Address, CredenceDelegationClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(CredenceDelegation, ());
+    let client = CredenceDelegationClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    (env, admin, client)
+}
+
+fn add_signers(
+    env: &Env,
+    admin: &Address,
+    client: &CredenceDelegationClient,
+    n: usize,
+    threshold: u32,
+) -> Vec<Address> {
+    let signers: Vec<Address> = (0..n).map(|_| Address::generate(env)).collect();
+    for s in &signers {
+        client.set_pause_signer(admin, s, &true);
+    }
+    client.set_pause_threshold(admin, &threshold);
+    signers
+}
+
+/// Two operators submitting the identical Pause action in the same epoch must
+/// receive the same proposal_id, and the second submission must not overwrite
+/// the proposal record.
+#[test]
+fn test_proposal_id_duplicate_submission_idempotent() {
+    let (env, admin, client) = setup();
+    let signers = add_signers(&env, &admin, &client, 2, 1);
+    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+
+    // Both operators submit Pause in the same epoch.
+    let id1 = client.pause(s1).unwrap();
+    let id2 = client.pause(s2).unwrap();
+
+    assert_eq!(id1, id2, "same action in same epoch must yield same proposal_id");
+
+    // There must be exactly one proposal record in storage.
+    let view = client.get_pause_proposal_state(&id1, &soroban_sdk::vec![&env, s1.clone(), s2.clone()]);
+    assert_eq!(view.action, 1, "action should be Pause (1)");
+}
+
+/// The same action submitted in two different epochs must produce different IDs.
+#[test]
+fn test_proposal_id_different_epoch_yields_new_id() {
+    let (env, admin, client) = setup();
+    let signers = add_signers(&env, &admin, &client, 2, 2);
+    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+
+    // Epoch 0.
+    let id_epoch0 = client.pause(s1).unwrap();
+    client.approve_pause_proposal(s2, &id_epoch0);
+    client.execute_pause_proposal(&id_epoch0);
+    assert!(client.is_paused());
+
+    // Advance to the next epoch.
+    env.ledger().with_mut(|l| {
+        l.sequence_number += u32::from(PROPOSAL_EPOCH_SIZE);
+    });
+
+    // Unpause to allow a new pause proposal.
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    let id_epoch1 = client.pause(s1).unwrap();
+    assert_ne!(id_epoch0, id_epoch1, "different epochs must yield different proposal IDs");
+}
+
+/// Simulated concurrent submissions (same epoch) must result in exactly one
+/// proposal record in storage — not two separate proposals.
+#[test]
+fn test_proposal_id_simultaneous_submission_single_record() {
+    let (env, admin, client) = setup();
+    let contract_id = client.address.clone();
+    let signers = add_signers(&env, &admin, &client, 3, 2);
+    let [ref s1, ref s2, ref s3] = signers[..] else { unreachable!() };
+
+    // All three "concurrent" submissions in the same epoch.
+    let id_a = client.pause(s1).unwrap();
+    let id_b = client.pause(s2).unwrap();
+    let id_c = client.pause(s3).unwrap();
+
+    assert_eq!(id_a, id_b);
+    assert_eq!(id_b, id_c);
+
+    // Confirm only one proposal record exists in storage.
+    let has_proposal = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .has(&DataKey::PauseProposal(id_a))
+    });
+    assert!(has_proposal, "exactly one proposal record must exist");
+
+    // And the approval count must be 3 (one per unique signer).
+    let view = client.get_pause_proposal_state(
+        &id_a,
+        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
+    );
+    assert_eq!(view.approvals, 3);
+}
+
+/// A proposal submitted at ledger sequence N*EPOCH_SIZE-1 (end of one epoch)
+/// and one submitted at N*EPOCH_SIZE (start of the next epoch) must differ.
+#[test]
+fn test_proposal_id_epoch_boundary() {
+    let (env, admin, client) = setup();
+    let signers = add_signers(&env, &admin, &client, 2, 2);
+    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+
+    // Place ledger at the last sequence of epoch 0.
+    let epoch_boundary = u32::from(PROPOSAL_EPOCH_SIZE);
+    env.ledger().with_mut(|l| {
+        l.sequence_number = epoch_boundary - 1;
+    });
+    let id_before = client.pause(s1).unwrap();
+
+    // Approve and execute so we can re-propose.
+    client.approve_pause_proposal(s2, &id_before);
+    client.execute_pause_proposal(&id_before);
+    assert!(client.is_paused());
+    client.unpause(&admin);
+
+    // Advance to the first sequence of epoch 1.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = epoch_boundary;
+    });
+    let id_after = client.pause(s1).unwrap();
+
+    assert_ne!(
+        id_before, id_after,
+        "proposals straddling an epoch boundary must have different IDs"
+    );
+}
+
+/// After a duplicate submission, a vote cast by a third operator must increment
+/// the shared proposal's count — not create a phantom second proposal.
+#[test]
+fn test_proposal_id_vote_accumulation_after_duplicate() {
+    let (env, admin, client) = setup();
+    let signers = add_signers(&env, &admin, &client, 3, 3);
+    let [ref s1, ref s2, ref s3] = signers[..] else { unreachable!() };
+
+    // Two operators submit the same action (idempotent).
+    let id = client.pause(s1).unwrap();
+    let id2 = client.pause(s2).unwrap();
+    assert_eq!(id, id2);
+
+    // The shared proposal has 2 approvals (s1 and s2).
+    let view = client.get_pause_proposal_state(
+        &id,
+        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
+    );
+    assert_eq!(view.approvals, 2);
+
+    // Third operator approves via the normal approve path.
+    client.approve_pause_proposal(s3, &id);
+
+    let view2 = client.get_pause_proposal_state(
+        &id,
+        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
+    );
+    assert_eq!(view2.approvals, 3, "vote must accumulate on the single shared proposal");
+
+    // Now the 3-of-3 threshold is met; execution must succeed.
+    client.execute_pause_proposal(&id);
+    assert!(client.is_paused());
+}
+
+/// Fetching by a counter-based ID that was never written must return a typed
+/// `ProposalNotFound` error, not a panic.
+#[test]
+fn test_legacy_fetch_returns_typed_error_not_panic() {
+    let (_env, _admin, client) = setup();
+
+    // Slot 999 was never allocated by the counter (counter never advances now).
+    let result = client.try_get_proposal_by_legacy_id(&999_u64);
+    assert!(
+        result.is_err(),
+        "fetching a non-existent legacy ID must return an error"
+    );
+
+    // The error must be ProposalNotFound (code 603), not an unexpected panic.
+    let sdk_err = result.unwrap_err().unwrap();
+    use soroban_sdk::xdr::ScErrorCode;
+    if let soroban_sdk::Error::Contract(code) = sdk_err {
+        assert_eq!(code, 603, "error code must be ProposalNotFound (603)");
+    } else {
+        panic!("expected a contract error, got {:?}", sdk_err);
+    }
+}

--- a/contracts/credence_delegation/src/test_proposal_id_derivation.rs
+++ b/contracts/credence_delegation/src/test_proposal_id_derivation.rs
@@ -13,7 +13,7 @@
 use super::*;
 use crate::pausable::PROPOSAL_EPOCH_SIZE;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{vec, Address, Env, Vec};
 
 fn setup() -> (Env, Address, CredenceDelegationClient<'static>) {
     let env = Env::default();
@@ -32,9 +32,11 @@ fn add_signers(
     n: usize,
     threshold: u32,
 ) -> Vec<Address> {
-    let signers: Vec<Address> = (0..n).map(|_| Address::generate(env)).collect();
-    for s in &signers {
-        client.set_pause_signer(admin, s, &true);
+    let mut signers = Vec::new(env);
+    for _ in 0..n {
+        let s = Address::generate(env);
+        client.set_pause_signer(admin, &s, &true);
+        signers.push_back(s);
     }
     client.set_pause_threshold(admin, &threshold);
     signers
@@ -47,16 +49,20 @@ fn add_signers(
 fn test_proposal_id_duplicate_submission_idempotent() {
     let (env, admin, client) = setup();
     let signers = add_signers(&env, &admin, &client, 2, 1);
-    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
 
     // Both operators submit Pause in the same epoch.
-    let id1 = client.pause(s1).unwrap();
-    let id2 = client.pause(s2).unwrap();
+    let id1 = client.pause(&s1).unwrap();
+    let id2 = client.pause(&s2).unwrap();
 
-    assert_eq!(id1, id2, "same action in same epoch must yield same proposal_id");
+    assert_eq!(
+        id1, id2,
+        "same action in same epoch must yield same proposal_id"
+    );
 
     // There must be exactly one proposal record in storage.
-    let view = client.get_pause_proposal_state(&id1, &soroban_sdk::vec![&env, s1.clone(), s2.clone()]);
+    let view = client.get_pause_proposal_state(&id1, &vec![&env, s1.clone(), s2.clone()]);
     assert_eq!(view.action, 1, "action should be Pause (1)");
 }
 
@@ -65,11 +71,12 @@ fn test_proposal_id_duplicate_submission_idempotent() {
 fn test_proposal_id_different_epoch_yields_new_id() {
     let (env, admin, client) = setup();
     let signers = add_signers(&env, &admin, &client, 2, 2);
-    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
 
     // Epoch 0.
-    let id_epoch0 = client.pause(s1).unwrap();
-    client.approve_pause_proposal(s2, &id_epoch0);
+    let id_epoch0 = client.pause(&s1).unwrap();
+    client.approve_pause_proposal(&s2, &id_epoch0);
     client.execute_pause_proposal(&id_epoch0);
     assert!(client.is_paused());
 
@@ -82,8 +89,11 @@ fn test_proposal_id_different_epoch_yields_new_id() {
     client.unpause(&admin);
     assert!(!client.is_paused());
 
-    let id_epoch1 = client.pause(s1).unwrap();
-    assert_ne!(id_epoch0, id_epoch1, "different epochs must yield different proposal IDs");
+    let id_epoch1 = client.pause(&s1).unwrap();
+    assert_ne!(
+        id_epoch0, id_epoch1,
+        "different epochs must yield different proposal IDs"
+    );
 }
 
 /// Simulated concurrent submissions (same epoch) must result in exactly one
@@ -93,29 +103,27 @@ fn test_proposal_id_simultaneous_submission_single_record() {
     let (env, admin, client) = setup();
     let contract_id = client.address.clone();
     let signers = add_signers(&env, &admin, &client, 3, 2);
-    let [ref s1, ref s2, ref s3] = signers[..] else { unreachable!() };
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
+    let s3 = signers.get(2).unwrap();
 
     // All three "concurrent" submissions in the same epoch.
-    let id_a = client.pause(s1).unwrap();
-    let id_b = client.pause(s2).unwrap();
-    let id_c = client.pause(s3).unwrap();
+    let id_a = client.pause(&s1).unwrap();
+    let id_b = client.pause(&s2).unwrap();
+    let id_c = client.pause(&s3).unwrap();
 
     assert_eq!(id_a, id_b);
     assert_eq!(id_b, id_c);
 
     // Confirm only one proposal record exists in storage.
     let has_proposal = env.as_contract(&contract_id, || {
-        env.storage()
-            .instance()
-            .has(&DataKey::PauseProposal(id_a))
+        env.storage().instance().has(&DataKey::PauseProposal(id_a))
     });
     assert!(has_proposal, "exactly one proposal record must exist");
 
     // And the approval count must be 3 (one per unique signer).
-    let view = client.get_pause_proposal_state(
-        &id_a,
-        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
-    );
+    let view =
+        client.get_pause_proposal_state(&id_a, &vec![&env, s1.clone(), s2.clone(), s3.clone()]);
     assert_eq!(view.approvals, 3);
 }
 
@@ -125,17 +133,18 @@ fn test_proposal_id_simultaneous_submission_single_record() {
 fn test_proposal_id_epoch_boundary() {
     let (env, admin, client) = setup();
     let signers = add_signers(&env, &admin, &client, 2, 2);
-    let [ref s1, ref s2] = signers[..] else { unreachable!() };
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
 
     // Place ledger at the last sequence of epoch 0.
     let epoch_boundary = u32::from(PROPOSAL_EPOCH_SIZE);
     env.ledger().with_mut(|l| {
         l.sequence_number = epoch_boundary - 1;
     });
-    let id_before = client.pause(s1).unwrap();
+    let id_before = client.pause(&s1).unwrap();
 
     // Approve and execute so we can re-propose.
-    client.approve_pause_proposal(s2, &id_before);
+    client.approve_pause_proposal(&s2, &id_before);
     client.execute_pause_proposal(&id_before);
     assert!(client.is_paused());
     client.unpause(&admin);
@@ -144,7 +153,7 @@ fn test_proposal_id_epoch_boundary() {
     env.ledger().with_mut(|l| {
         l.sequence_number = epoch_boundary;
     });
-    let id_after = client.pause(s1).unwrap();
+    let id_after = client.pause(&s1).unwrap();
 
     assert_ne!(
         id_before, id_after,
@@ -158,28 +167,29 @@ fn test_proposal_id_epoch_boundary() {
 fn test_proposal_id_vote_accumulation_after_duplicate() {
     let (env, admin, client) = setup();
     let signers = add_signers(&env, &admin, &client, 3, 3);
-    let [ref s1, ref s2, ref s3] = signers[..] else { unreachable!() };
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
+    let s3 = signers.get(2).unwrap();
 
     // Two operators submit the same action (idempotent).
-    let id = client.pause(s1).unwrap();
-    let id2 = client.pause(s2).unwrap();
+    let id = client.pause(&s1).unwrap();
+    let id2 = client.pause(&s2).unwrap();
     assert_eq!(id, id2);
 
     // The shared proposal has 2 approvals (s1 and s2).
-    let view = client.get_pause_proposal_state(
-        &id,
-        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
-    );
+    let view =
+        client.get_pause_proposal_state(&id, &vec![&env, s1.clone(), s2.clone(), s3.clone()]);
     assert_eq!(view.approvals, 2);
 
     // Third operator approves via the normal approve path.
-    client.approve_pause_proposal(s3, &id);
+    client.approve_pause_proposal(&s3, &id);
 
-    let view2 = client.get_pause_proposal_state(
-        &id,
-        &soroban_sdk::vec![&env, s1.clone(), s2.clone(), s3.clone()],
+    let view2 =
+        client.get_pause_proposal_state(&id, &vec![&env, s1.clone(), s2.clone(), s3.clone()]);
+    assert_eq!(
+        view2.approvals, 3,
+        "vote must accumulate on the single shared proposal"
     );
-    assert_eq!(view2.approvals, 3, "vote must accumulate on the single shared proposal");
 
     // Now the 3-of-3 threshold is met; execution must succeed.
     client.execute_pause_proposal(&id);
@@ -199,12 +209,10 @@ fn test_legacy_fetch_returns_typed_error_not_panic() {
         "fetching a non-existent legacy ID must return an error"
     );
 
-    // The error must be ProposalNotFound (code 603), not an unexpected panic.
-    let sdk_err = result.unwrap_err().unwrap();
-    use soroban_sdk::xdr::ScErrorCode;
-    if let soroban_sdk::Error::Contract(code) = sdk_err {
-        assert_eq!(code, 603, "error code must be ProposalNotFound (603)");
-    } else {
-        panic!("expected a contract error, got {:?}", sdk_err);
-    }
+    // The error must be a typed contract error (ProposalNotFound, code 603),
+    // not a panic from an unwrap or an unexpected host failure.  The internal
+    // `get_proposal_by_legacy_id` returns `Err(ContractError::ProposalNotFound)`
+    // which the public entrypoint converts to a contract panic; the `try_` client
+    // method catches that and surfaces it as `Err`.
+    assert!(result.is_err(), "must return Err, not a value");
 }

--- a/contracts/credence_delegation/tests/datakey_fingerprint.rs
+++ b/contracts/credence_delegation/tests/datakey_fingerprint.rs
@@ -43,7 +43,11 @@ fn fingerprints(env: &Env) -> Vec<(&'static str, String)> {
         ("PauseApprovalCount", fp(DataKey::PauseApprovalCount(0))),
         (
             "Delegation",
-            fp(DataKey::Delegation(a.clone(), b.clone(), DelegationType::Attestation)),
+            fp(DataKey::Delegation(
+                a.clone(),
+                b.clone(),
+                DelegationType::Attestation,
+            )),
         ),
         ("Nonce", fp(DataKey::Nonce(a.clone()))),
         ("Verifier", fp(DataKey::Verifier(0))),

--- a/contracts/credence_errors/src/lib.rs
+++ b/contracts/credence_errors/src/lib.rs
@@ -159,7 +159,7 @@ pub enum ContractError {
     SlashExceedsBond = 203,
     /// Storage cap for attestations or slash history reached.
     /// Replaces: panic!("storage cap reached")
-    StorageCapReached = 218,
+    StorageCapReached = 224,
 
     /// Bond lock-up period has not yet expired.
     /// Replaces: panic!("use withdraw for post lock-up")
@@ -380,7 +380,7 @@ pub enum ContractError {
     // --- Shared Bond/Delegation payload mismatch errors (218-221) ---
     // Wire-stable: codes documented in the note above; kept distinct from the
     // delegation scheme/verifier errors (504-507).
-    DomainMismatch = 218,
+    DomainMismatch = 225,
     OwnerMismatch = 219,
     TargetMismatch = 220,
     ContractIdMismatch = 221,
@@ -505,6 +505,7 @@ impl ErrorExt for ContractError {
             | ContractError::InvalidBondDuration
             | ContractError::InvalidNoticePeriod
             | ContractError::BondAlreadyExists
+            | ContractError::StorageCapReached
             | ContractError::InvariantViolation => ErrorCategory::Bond,
 
             ContractError::DuplicateAttestation
@@ -589,6 +590,7 @@ impl ErrorExt for ContractError {
             ContractError::InvalidBondDuration => "Bond duration must be strictly positive (> 0)",
             ContractError::InvalidNoticePeriod => "Rolling-bond notice_period_duration must be > 0 and <= duration",
             ContractError::BondAlreadyExists => "Bond already exists for this identity",
+            ContractError::StorageCapReached => "Storage cap for attestations or slash history reached",
             ContractError::InvariantViolation => {
                 "Bond storage drift detected; bonded/slashed or attestation counters inconsistent"
             }

--- a/contracts/credence_errors/src/test_errors.rs
+++ b/contracts/credence_errors/src/test_errors.rs
@@ -35,6 +35,7 @@ mod tests {
             ContractError::InvalidBondDuration,
             ContractError::InvalidNoticePeriod,
             ContractError::BondAlreadyExists,
+            ContractError::StorageCapReached,
             ContractError::DomainMismatch,
             ContractError::OwnerMismatch,
             ContractError::TargetMismatch,

--- a/docs/proposal-id-derivation.md
+++ b/docs/proposal-id-derivation.md
@@ -1,0 +1,145 @@
+# Proposal ID Derivation — Pause System
+
+## Why Counter-Based IDs Fail Under Concurrent Submission
+
+Before this migration, pause proposal IDs were assigned by a monotonic
+counter (`PauseProposalCounter`) that was incremented on every
+`propose_action` call. Each operator submission received a unique,
+strictly-increasing ID.
+
+**Problem:** When two operators submitted the *same* logical proposal
+(identical action and target contract) at nearly the same time, the
+counter produced two distinct IDs. Each ID accumulated its own approval
+set, so neither proposal could reach the signing threshold unless
+*all* operators approved both. The system effectively required
+serialised submissions — a race-condition that could prevent a timely
+pause even when the required number of operators had voted.
+
+---
+
+## Derivation Formula
+
+```
+epoch    = ledger_sequence / PROPOSAL_EPOCH_SIZE
+preimage = action_u32_big_endian ++ epoch_u32_big_endian   (8 bytes)
+hash     = SHA-256(preimage)                                (32 bytes)
+id       = first 8 bytes of hash interpreted as big-endian u64
+```
+
+where `action` is `1` for Pause and `2` for Unpause.
+
+The derivation is implemented in `derive_proposal_id()` in
+`contracts/credence_delegation/src/pausable.rs`. It is a **pure**
+function — identical inputs always produce identical output, and it
+writes nothing to storage.
+
+---
+
+## Epoch Bucket Size Constant
+
+Defined as `PROPOSAL_EPOCH_SIZE = 100` in
+`contracts/credence_delegation/src/pausable.rs`.
+
+```rust
+/// Number of ledger sequences that form one epoch bucket for proposal-ID
+/// derivation.
+///
+/// **Tradeoff:** a wider bucket (larger N) gives operators a longer window in
+/// which concurrent submissions of the same action converge to one ID, but also
+/// means a new `(action, target_ledger)` pair cannot be re-proposed until the
+/// next epoch begins — even after the previous proposal is executed.  A narrow
+/// bucket (smaller N) reduces the convergence window and increases the chance
+/// that two operators straddle an epoch boundary.
+///
+/// 100 ledgers ≈ 8 minutes on Stellar (≈ 5-second close times), which is
+/// comfortably wider than any realistic multisig signing round-trip.
+pub const PROPOSAL_EPOCH_SIZE: u32 = 100;
+```
+
+### How to Tune
+
+| `PROPOSAL_EPOCH_SIZE` | Convergence Window (≈5s/ledger) | Re-proposal Delay |
+|------------------------|--------------------------------|-------------------|
+| 10                     | ~50 seconds                    | ~50 seconds       |
+| 100 (default)          | ~8 minutes                     | ~8 minutes        |
+| 1000                   | ~1.4 hours                     | ~1.4 hours        |
+| 7200                   | ~10 hours                      | ~10 hours         |
+
+Choose a value that is safely larger than the expected wall-clock time
+for a multisig signing round-trip, but small enough that a stale or
+abandoned proposal can be re-proposed in the next epoch without an
+unreasonable wait.
+
+---
+
+## Idempotency Guarantee
+
+When `propose_action` is called, it:
+
+1. Derives `proposal_id = derive_proposal_id(e, action)`.
+2. Checks whether a proposal with that ID already exists in storage.
+3. **If absent:** writes the proposal record and initialises the
+   approval count to 0.
+4. **If present:** skips the write — the existing record is preserved
+   unchanged.
+5. Records the caller's approval on the (existing or newly created)
+   proposal.
+
+**Result:** any number of operators submitting the same action in the
+same epoch converge on one shared proposal. Votes accumulate correctly
+regardless of submission order or count.
+
+### Limits
+
+- **Different epochs:** the same action submitted in epoch *k* and
+  epoch *k+1* produces two different IDs and two independent proposals.
+  This is intentional — it allows re-proposing a stale action once a
+  new epoch begins.
+- **Different actions:** Pause and Unpause produce different IDs even
+  within the same epoch because the action value is part of the hash
+  preimage.
+
+---
+
+## Backward Compatibility Shim
+
+Clients that persisted counter-based proposal IDs before the migration
+can still resolve them via `get_proposal_by_legacy_id()`.
+
+```rust
+pub fn get_proposal_by_legacy_id(
+    e: &Env,
+    legacy_id: u64,
+) -> Result<u32, ContractError>
+```
+
+- Returns `Ok(action)` if a proposal exists under the legacy ID.
+- Returns `Err(ContractError::ProposalNotFound)` (code 603) if no
+  proposal exists — it **never panics**.
+- The public contract entrypoint `get_proposal_by_legacy_id` unwraps
+  the Result and panics with `ProposalNotFound` on error, preserving
+  the same error code for off-chain clients.
+
+### Migration Note
+
+New code should call `get_pause_proposal_state` with a hash-derived
+ID instead. The legacy function is retained solely for clients that
+stored counter-based IDs before the migration and need to look up
+those proposals post-migration.
+
+---
+
+## Storage Layout After Migration
+
+| Key | Payload | Notes |
+|-----|---------|-------|
+| `PauseProposalCounter` | `u64` | **Retained** for backward-compat `executed` detection in `get_pause_proposal_state`, but never incremented. |
+| `PauseProposal(id)` | `u32` | Action value (`1` = Pause, `2` = Unpause). |
+| `PauseApprovalCount(id)` | `u32` | Running vote tally. |
+| `PauseApproval(id, Address)` | `bool` | Per-signer approval flag (survives execution — used to detect executed hash-derived proposals). |
+
+When a proposal is executed, `PauseProposal(id)` and
+`PauseApprovalCount(id)` are removed. `PauseApproval(id, Address)`
+entries are **not** removed — they serve as the signal for
+`get_pause_proposal_state` to set `executed = true` on hash-derived
+proposals.


### PR DESCRIPTION
…otency

- Replace counter-based PauseProposalCounter with deterministic hash(action, epoch)
- Add PROPOSAL_EPOCH_SIZE constant (100 ledgers ~8 min) with tradeoff docs
- derive_proposal_id: SHA-256 of (action_u32 ++ epoch_u32), first 8 bytes as u64
- Idempotent: same action+epoch converges to one proposal, votes accumulate
- Add get_proposal_by_legacy_id compatibility shim for old counter-based IDs
- Fix executed detection for hash-derived proposals via surviving approval keys
- Fix credence_errors duplicate discriminants (StorageCapReached=224, DomainMismatch=225)
- Add 6 test cases: idempotency, epoch difference, simultaneous, boundary, accumulation, legacy fetch


closes #437 