### PR TITLE
docs: fix README build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Part of [Credence](../README.md). Contracts run on the Stellar network via Sorob
 From the repo root:
 
 ```bash
-cd credence-contracts
 cargo build
 ```
 


### PR DESCRIPTION
 calls out that verify_payload collapses all mismatches into InvalidNonce. Beyond renaming, we should introduce a fine-grained set: DomainMismatch, OwnerMismatch, TargetMismatch, ContractIdMismatch. This enables off-chain monitors to distinguish replay attempts from misconfigured relayers. Wire-stable codes must be appended at end of the Delegation block (500-599).

Requirements and context

closes #441 